### PR TITLE
Recalculation of test values

### DIFF
--- a/tests/capability_index_test.py
+++ b/tests/capability_index_test.py
@@ -18,29 +18,39 @@ def run_data_test(file_index, test_data):
 
     # Extract the required data for the test
     data = np.array(current_set["data"])
+    error = current_set["error"]
     upper_extreme = current_set["upper_extreme"]
     lower_extreme = current_set["lower_extreme"]
     upper_specification = current_set["upper_specification"]
     lower_specification = current_set["lower_specification"]
-    cp_pointed_expected = current_set["cp_point"]
-    cpk_pointed_expected = current_set["cpk_point"]
-    cp_interval = current_set["cp_interval"]
-    cpk_interval = current_set["cpk_interval"]
 
-    # Perform the evaluation on the dataset
-    result = evaluate(
-        np.array(data),
-        specification_limits=(lower_specification, upper_specification),
-        data_boundaries=(lower_extreme, upper_extreme),
-        random_seed=0
-    )
+    if error is not None:
+        try:
+            evaluate(data, specification_limits=(lower_specification, upper_specification),
+                     data_boundaries=(lower_extreme, upper_extreme), random_seed=0, samples=200)
+        except Exception as e:
+            assert str(e) == error
 
-    # Assert the results
-    assert_almost_equal(result.capability_index.cp.point, cp_pointed_expected, decimal=2)
-    assert_almost_equal(result.capability_index.cpk.point, cpk_pointed_expected, decimal=2)
-    for i in range(2):
-        assert_almost_equal(result.capability_index.cp.interval[i], cp_interval[i], decimal=2)
-        assert_almost_equal(result.capability_index.cpk.interval[i], cpk_interval[i], decimal=2)
+    else:
+        cp_pointed_expected = current_set["cp_point"]
+        cpk_pointed_expected = current_set["cpk_point"]
+        cp_interval = current_set["cp_interval"]
+        cpk_interval = current_set["cpk_interval"]
+
+        # Perform the evaluation on the dataset
+        result = evaluate(
+            np.array(data),
+            specification_limits=(lower_specification, upper_specification),
+            data_boundaries=(lower_extreme, upper_extreme),
+            random_seed=0
+        )
+
+        # Assert the results
+        assert_almost_equal(result.capability_index.cp.point, cp_pointed_expected, decimal=2)
+        assert_almost_equal(result.capability_index.cpk.point, cpk_pointed_expected, decimal=2)
+        for i in range(2):
+            assert_almost_equal(result.capability_index.cp.interval[i], cp_interval[i], decimal=2)
+            assert_almost_equal(result.capability_index.cpk.interval[i], cpk_interval[i], decimal=2)
 
 
 test_data = load_test_data()

--- a/tests/capability_index_test.py
+++ b/tests/capability_index_test.py
@@ -25,11 +25,12 @@ def run_data_test(file_index, test_data):
     lower_specification = current_set["lower_specification"]
 
     if error is not None:
-        try:
-            evaluate(data, specification_limits=(lower_specification, upper_specification),
-                     data_boundaries=(lower_extreme, upper_extreme), random_seed=0, samples=200)
-        except Exception as e:
-            assert str(e) == error
+        with pytest.raises(Exception, match=error):
+            evaluate(data,
+                     specification_limits=(lower_specification, upper_specification),
+                     data_boundaries=(lower_extreme, upper_extreme),
+                     random_seed=0,
+                     samples=200)
 
     else:
         cp_pointed_expected = current_set["cp_point"]
@@ -38,12 +39,10 @@ def run_data_test(file_index, test_data):
         cpk_interval = current_set["cpk_interval"]
 
         # Perform the evaluation on the dataset
-        result = evaluate(
-            np.array(data),
-            specification_limits=(lower_specification, upper_specification),
-            data_boundaries=(lower_extreme, upper_extreme),
-            random_seed=0
-        )
+        result = evaluate(np.array(data),
+                          specification_limits=(lower_specification, upper_specification),
+                          data_boundaries=(lower_extreme, upper_extreme),
+                          random_seed=0)
 
         # Assert the results
         assert_almost_equal(result.capability_index.cp.point, cp_pointed_expected, decimal=2)
@@ -83,4 +82,14 @@ def test_index_outliers(file_index):
 @pytest.mark.parametrize("file_index", [29])
 def test_index_heavy_tail(file_index):
     # Test the capability index calculation of different continuous data sets
+    run_data_test(file_index, test_data)
+
+
+@pytest.mark.parametrize("file_index", [8, 10, 178])
+def test_error_non_unique_values(file_index):
+    run_data_test(file_index, test_data)
+
+
+@pytest.mark.parametrize("file_index", [559, 560, 561])
+def test_error_not_enough_values(file_index):
     run_data_test(file_index, test_data)

--- a/tests/test_data/test_data.json
+++ b/tests/test_data/test_data.json
@@ -7,14 +7,15 @@
         "lower_extreme": 0,
         "upper_specification": 5,
         "lower_specification": null,
-        "cp_point": 0.7779625101508444,
-        "cpk_point": 0.6442619177818262,
+        "cp_point": 0.778,
+        "cpk_point": 0.644,
         "cp_interval": [
-            0.6301731703189136, 0.9233236330499246
+            0.63, 0.923
         ],
         "cpk_interval": [
-            0.4832466492046776, 0.8297711186090635
-        ]
+            0.483, 0.83
+        ],
+        "error": null
     },
     "file1": {
         "data": [
@@ -31,7 +32,8 @@
         ],
         "cpk_interval": [
             null, null
-        ]
+        ],
+        "error": null
     },
     "file2": {
         "data": [
@@ -48,7 +50,8 @@
         ],
         "cpk_interval": [
             null, null
-        ]
+        ],
+        "error": null
     },
     "file3": {
         "data": [
@@ -65,7 +68,8 @@
         ],
         "cpk_interval": [
             null, null
-        ]
+        ],
+        "error": null
     },
     "file4": {
         "data": [
@@ -82,7 +86,8 @@
         ],
         "cpk_interval": [
             null, null
-        ]
+        ],
+        "error": null
     },
     "file5": {
         "data": [
@@ -99,7 +104,8 @@
         ],
         "cpk_interval": [
             null, null
-        ]
+        ],
+        "error": null
     },
     "file6": {
         "data": [
@@ -109,14 +115,15 @@
         "lower_extreme": null,
         "upper_specification": null,
         "lower_specification": null,
-        "cp_point": 0.8850426011335166,
-        "cpk_point": 0.8624668302009156,
+        "cp_point": null,
+        "cpk_point": null,
         "cp_interval": [
-            0.8302915759940506, 0.909798807695933
+            null, null
         ],
         "cpk_interval": [
-            0.8052476481702509, 0.8990588549824697
-        ]
+            null, null
+        ],
+        "error": null
     },
     "file7": {
         "data": [
@@ -126,14 +133,15 @@
         "lower_extreme": null,
         "upper_specification": null,
         "lower_specification": null,
-        "cp_point": 0.9267822102651998,
-        "cpk_point": 0.910863706630449,
+        "cp_point": null,
+        "cpk_point": null,
         "cp_interval": [
-            0.9059807147548176, 0.9467325741878843
+            null, null
         ],
         "cpk_interval": [
-            0.8666457081700131, 0.9371511925370364
-        ]
+            null, null
+        ],
+        "error": null
     },
     "file8": {
         "data": [
@@ -142,7 +150,16 @@
         "upper_extreme": null,
         "lower_extreme": null,
         "upper_specification": null,
-        "lower_specification": null
+        "lower_specification": null,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More unique values are required to calculate capability indexes."
     },
     "file9": {
         "data": [
@@ -152,14 +169,15 @@
         "lower_extreme": null,
         "upper_specification": null,
         "lower_specification": null,
-        "cp_point": 0.8923522856141558,
-        "cpk_point": 0.8897614369532447,
+        "cp_point": null,
+        "cpk_point": null,
         "cp_interval": [
-            0.863586778467091, 0.9201700572407042
+            null, null
         ],
         "cpk_interval": [
-            0.8288842549492275, 0.9123879614379908
-        ]
+            null, null
+        ],
+        "error": null
     },
     "file10": {
         "data": [
@@ -168,7 +186,16 @@
         "upper_extreme": null,
         "lower_extreme": null,
         "upper_specification": null,
-        "lower_specification": null
+        "lower_specification": null,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More unique values are required to calculate capability indexes."
     },
     "file11": {
         "data": [
@@ -178,14 +205,15 @@
         "lower_extreme": null,
         "upper_specification": -11.0,
         "lower_specification": -29.0,
-        "cp_point": 0.6034556639360946,
-        "cpk_point": 0.2754457126440554,
+        "cp_point": 0.603,
+        "cpk_point": 0.275,
         "cp_interval": [
-            0.45892155301642057, 0.729568059424482
+            0.459, 0.73
         ],
         "cpk_interval": [
-            0.17133096738772308, 0.4009316309652626
-        ]
+            0.171, 0.401
+        ],
+        "error": null
     },
     "file12": {
         "data": [
@@ -195,14 +223,15 @@
         "lower_extreme": null,
         "upper_specification": 10.0,
         "lower_specification": 2.0,
-        "cp_point": 1.9425440004061056,
-        "cpk_point": 1.047171084105663,
+        "cp_point": 1.943,
+        "cpk_point": 1.047,
         "cp_interval": [
-            1.5901509919415624, 2.263445505425414
+            1.59, 2.263
         ],
         "cpk_interval": [
-            0.8322720232365415, 1.2756109626534116
-        ]
+            0.832, 1.276
+        ],
+        "error": null
     },
     "file13": {
         "data": [
@@ -212,14 +241,15 @@
         "lower_extreme": null,
         "upper_specification": -11.0,
         "lower_specification": -29.0,
-        "cp_point": 0.5809536285642126,
-        "cpk_point": -0.19589402434533415,
+        "cp_point": 0.581,
+        "cpk_point": -0.196,
         "cp_interval": [
-            0.45183642859752704, 0.6847286994824661
+            0.452, 0.685
         ],
         "cpk_interval": [
-            -0.30811603554743133, -0.025102177519338728
-        ]
+            -0.308, -0.025
+        ],
+        "error": null
     },
     "file14": {
         "data": [
@@ -229,14 +259,15 @@
         "lower_extreme": null,
         "upper_specification": 10.0,
         "lower_specification": 2.0,
-        "cp_point": 1.285331400094067,
-        "cpk_point": 1.1103255760062731,
+        "cp_point": 1.285,
+        "cpk_point": 1.11,
         "cp_interval": [
-            1.058726612234958, 1.4874155872372359
+            1.059, 1.487
         ],
         "cpk_interval": [
-            0.8988628906830498, 1.2809233904458308
-        ]
+            0.899, 1.281
+        ],
+        "error": null
     },
     "file15": {
         "data": [
@@ -246,14 +277,15 @@
         "lower_extreme": null,
         "upper_specification": -1.0,
         "lower_specification": -19.0,
-        "cp_point": 0.5918076881168047,
-        "cpk_point": 0.4522769583423467,
+        "cp_point": 0.592,
+        "cpk_point": 0.452,
         "cp_interval": [
-            0.4622454942806607, 0.7051788917096076
+            0.462, 0.705
         ],
         "cpk_interval": [
-            0.3153643210168157, 0.5672833154250728
-        ]
+            0.315, 0.567
+        ],
+        "error": null
     },
     "file16": {
         "data": [
@@ -263,14 +295,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.180170875038669,
-        "cpk_point": 0.36647617807604516,
+        "cp_point": 1.18,
+        "cpk_point": 0.366,
         "cp_interval": [
-            0.7358880889277558, 1.4476229196393127
+            0.736, 1.448
         ],
         "cpk_interval": [
-            0.193987221733952, 0.49176385299002573
-        ]
+            0.194, 0.492
+        ],
+        "error": null
     },
     "file17": {
         "data": [
@@ -280,14 +313,15 @@
         "lower_extreme": null,
         "upper_specification": -1.0,
         "lower_specification": -19.0,
-        "cp_point": 0.5881018860322547,
-        "cpk_point": 0.3705720152383847,
+        "cp_point": 0.588,
+        "cpk_point": 0.371,
         "cp_interval": [
-            0.4507409827587677, 0.7076995388689025
+            0.451, 0.708
         ],
         "cpk_interval": [
-            0.24219665708496246, 0.48013632105817233
-        ]
+            0.242, 0.48
+        ],
+        "error": null
     },
     "file18": {
         "data": [
@@ -297,14 +331,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.1571303635215548,
-        "cpk_point": 0.7309140056484029,
+        "cp_point": 1.157,
+        "cpk_point": 0.731,
         "cp_interval": [
-            0.8417992379300837, 1.3658824131164873
+            0.842, 1.366
         ],
         "cpk_interval": [
-            0.49538366813579615, 0.9332236480892294
-        ]
+            0.495, 0.933
+        ],
+        "error": null
     },
     "file19": {
         "data": [
@@ -314,14 +349,15 @@
         "lower_extreme": null,
         "upper_specification": 11.0,
         "lower_specification": 5.0,
-        "cp_point": 0.9695094683450802,
-        "cpk_point": 0.6871646660316351,
+        "cp_point": 0.97,
+        "cpk_point": 0.687,
         "cp_interval": [
-            0.7799537268638677, 1.136518773374492
+            0.78, 1.137
         ],
         "cpk_interval": [
-            0.5272851555073655, 0.8682237211963949
-        ]
+            0.527, 0.868
+        ],
+        "error": null
     },
     "file20": {
         "data": [
@@ -331,14 +367,15 @@
         "lower_extreme": null,
         "upper_specification": 11.0,
         "lower_specification": 5.0,
-        "cp_point": 1.0597167538484678,
-        "cpk_point": 0.7037873734786788,
+        "cp_point": 1.06,
+        "cpk_point": 0.704,
         "cp_interval": [
-            0.8731285347479585, 1.231738474953495
+            0.873, 1.232
         ],
         "cpk_interval": [
-            0.5587854574042891, 0.8636227699894691
-        ]
+            0.559, 0.864
+        ],
+        "error": null
     },
     "file21": {
         "data": [
@@ -348,14 +385,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.463849756505553,
-        "cpk_point": 0.9087358502964382,
+        "cp_point": 1.536,
+        "cpk_point": 1.743,
         "cp_interval": [
-            1.2041507950300043, 1.7124977903313192
+            1.263, 1.797
         ],
         "cpk_interval": [
-            0.8380075267910122, 0.969647195980799
-        ]
+            1.351, 2.135
+        ],
+        "error": null
     },
     "file22": {
         "data": [
@@ -365,14 +403,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.3659151978452557,
-        "cpk_point": 0.8829370837171095,
+        "cp_point": 1.433,
+        "cpk_point": 1.593,
         "cp_interval": [
-            1.1205462561512807, 1.6042055196467244
+            1.176, 1.683
         ],
         "cpk_interval": [
-            0.8229544185249784, 0.9403864405312373
-        ]
+            1.23, 1.963
+        ],
+        "error": null
     },
     "file23": {
         "data": [
@@ -382,14 +421,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 0.6920428543161197,
-        "cpk_point": 0.6158017214777679,
+        "cp_point": 0.752,
+        "cpk_point": 0.616,
         "cp_interval": [
-            0.569349835131246, 0.8128641989364184
+            0.619, 0.883
         ],
         "cpk_interval": [
-            0.4640116618821451, 0.7894189750165811
-        ]
+            0.464, 0.789
+        ],
+        "error": null
     },
     "file24": {
         "data": [
@@ -399,14 +439,15 @@
         "lower_extreme": null,
         "upper_specification": 40.55,
         "lower_specification": 40.3,
-        "cp_point": 1.7387884327616951,
-        "cpk_point": 0.8458115522366446,
+        "cp_point": 1.739,
+        "cpk_point": 0.846,
         "cp_interval": [
-            1.4251389383356845, 2.017771946404128
+            1.425, 2.018
         ],
         "cpk_interval": [
-            0.6971913992599371, 1.005343444129188
-        ]
+            0.697, 1.005
+        ],
+        "error": null
     },
     "file25": {
         "data": [
@@ -416,14 +457,15 @@
         "lower_extreme": null,
         "upper_specification": 55.1,
         "lower_specification": 54.9,
-        "cp_point": 2.2476402663845954,
-        "cpk_point": 2.2116039462508414,
+        "cp_point": 2.248,
+        "cpk_point": 2.212,
         "cp_interval": [
-            1.840209255480335, 2.553530995202351
+            1.84, 2.554
         ],
         "cpk_interval": [
-            1.6481634778952137, 2.5191983629854886
-        ]
+            1.648, 2.519
+        ],
+        "error": null
     },
     "file26": {
         "data": [
@@ -433,14 +475,15 @@
         "lower_extreme": null,
         "upper_specification": 51.898,
         "lower_specification": 51.856,
-        "cp_point": 0.4096132446337318,
-        "cpk_point": 0.11769056825051238,
+        "cp_point": 0.41,
+        "cpk_point": 0.118,
         "cp_interval": [
-            0.2423063063581736, 0.46535744038993715
+            0.242, 0.465
         ],
         "cpk_interval": [
-            0.0521274341193187, 0.17442150212247304
-        ]
+            0.052, 0.174
+        ],
+        "error": null
     },
     "file27": {
         "data": [
@@ -450,14 +493,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": -6.0,
-        "cp_point": 1.6007919559001809,
-        "cpk_point": 1.2302740458924863,
+        "cp_point": 1.601,
+        "cpk_point": 1.23,
         "cp_interval": [
-            1.3053397987478648, 1.86936012348153
+            1.305, 1.869
         ],
         "cpk_interval": [
-            0.9761945499560133, 1.4925499829566986
-        ]
+            0.976, 1.493
+        ],
+        "error": null
     },
     "file28": {
         "data": [
@@ -467,14 +511,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": -6.0,
-        "cp_point": 1.3630414282843153,
-        "cpk_point": 1.0416703842138495,
+        "cp_point": 1.363,
+        "cpk_point": 1.042,
         "cp_interval": [
-            1.1108770761246571, 1.5913362645445457
+            1.111, 1.591
         ],
         "cpk_interval": [
-            0.8258555874031168, 1.2726781602251966
-        ]
+            0.826, 1.273
+        ],
+        "error": null
     },
     "file29": {
         "data": [
@@ -484,14 +529,15 @@
         "lower_extreme": null,
         "upper_specification": -11.0,
         "lower_specification": -29.0,
-        "cp_point": 0.6282128235898705,
-        "cpk_point": 0.4587590956009602,
+        "cp_point": 0.628,
+        "cpk_point": 0.459,
         "cp_interval": [
-            0.46431203262780185, 0.7889888420695949
+            0.464, 0.789
         ],
         "cpk_interval": [
-            0.3152488752533943, 0.633598270490435
-        ]
+            0.315, 0.634
+        ],
+        "error": null
     },
     "file30": {
         "data": [
@@ -501,14 +547,15 @@
         "lower_extreme": null,
         "upper_specification": -1.0,
         "lower_specification": -19.0,
-        "cp_point": 0.7967970501160968,
-        "cpk_point": 0.7296082577402093,
+        "cp_point": 0.797,
+        "cpk_point": 0.73,
         "cp_interval": [
-            0.6511039220770639, 0.9323070049411347
+            0.651, 0.932
         ],
         "cpk_interval": [
-            0.5750439862551039, 0.9022697838467548
-        ]
+            0.575, 0.902
+        ],
+        "error": null
     },
     "file31": {
         "data": [
@@ -518,14 +565,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 1.173725699185496,
-        "cpk_point": 1.1085722372776499,
+        "cp_point": 1.174,
+        "cpk_point": 1.109,
         "cp_interval": [
-            0.9585598507627056, 1.316677616043385
+            0.959, 1.317
         ],
         "cpk_interval": [
-            0.8074349909003752, 1.2750775664169742
-        ]
+            0.807, 1.275
+        ],
+        "error": null
     },
     "file32": {
         "data": [
@@ -535,14 +583,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.5713435233922907,
-        "cpk_point": 0.407816606490488,
+        "cp_point": 0.791,
+        "cpk_point": 0.408,
         "cp_interval": [
-            0.3623691700122252, 0.802478676367156
+            0.502, 1.111
         ],
         "cpk_interval": [
-            0.2273224295475826, 0.639520356332303
-        ]
+            0.227, 0.64
+        ],
+        "error": null
     },
     "file33": {
         "data": [
@@ -552,14 +601,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.1398473076443518,
-        "cpk_point": 0.770943671830888,
+        "cp_point": 1.28,
+        "cpk_point": 1.379,
         "cp_interval": [
-            0.9612605625756971, 1.3043193908883177
+            1.079, 1.465
         ],
         "cpk_interval": [
-            0.6937390372386738, 0.8376173417082291
-        ]
+            1.095, 1.662
+        ],
+        "error": null
     },
     "file34": {
         "data": [
@@ -569,14 +619,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.7107868732096194,
-        "cpk_point": 0.6252294958092053,
+        "cp_point": 0.8,
+        "cpk_point": 0.625,
         "cp_interval": [
-            0.5815882767079186, 0.8262903327513706
+            0.655, 0.93
         ],
         "cpk_interval": [
-            0.4741159747935178, 0.79160478251485
-        ]
+            0.474, 0.792
+        ],
+        "error": null
     },
     "file35": {
         "data": [
@@ -586,14 +637,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.7982713305409375,
-        "cpk_point": 0.7949838052769092,
+        "cp_point": 0.902,
+        "cpk_point": 0.795,
         "cp_interval": [
-            0.6697547830955655, 0.919927946649718
+            0.757, 1.04
         ],
         "cpk_interval": [
-            0.6199622137336872, 0.8553026148234245
-        ]
+            0.62, 0.99
+        ],
+        "error": null
     },
     "file36": {
         "data": [
@@ -603,14 +655,15 @@
         "lower_extreme": null,
         "upper_specification": 44.025,
         "lower_specification": 44.009,
-        "cp_point": 1.192672718367164,
-        "cpk_point": 1.1126039386206366,
+        "cp_point": 1.193,
+        "cpk_point": 1.113,
         "cp_interval": [
-            1.1032435627251862, 1.275524716353612
+            1.103, 1.276
         ],
         "cpk_interval": [
-            1.036125774546823, 1.1752102838773755
-        ]
+            1.036, 1.175
+        ],
+        "error": null
     },
     "file37": {
         "data": [
@@ -620,14 +673,15 @@
         "lower_extreme": null,
         "upper_specification": 44.025,
         "lower_specification": 44.009,
-        "cp_point": 1.158036567622327,
-        "cpk_point": 1.116872516430138,
+        "cp_point": 1.158,
+        "cpk_point": 1.117,
         "cp_interval": [
-            1.0737418942651145, 1.2351782179907123
+            1.074, 1.235
         ],
         "cpk_interval": [
-            1.0367966810146114, 1.199716695694029
-        ]
+            1.037, 1.2
+        ],
+        "error": null
     },
     "file38": {
         "data": [
@@ -637,14 +691,15 @@
         "lower_extreme": null,
         "upper_specification": 28.02,
         "lower_specification": 28.009,
-        "cp_point": 1.0317123455049253,
-        "cpk_point": 1.0035592516252065,
+        "cp_point": 1.032,
+        "cpk_point": 1.004,
         "cp_interval": [
-            0.9559090331248418, 1.09950543265493
+            0.956, 1.1
         ],
         "cpk_interval": [
-            0.9348214278012467, 1.0768845683972654
-        ]
+            0.935, 1.077
+        ],
+        "error": null
     },
     "file39": {
         "data": [
@@ -654,14 +709,15 @@
         "lower_extreme": null,
         "upper_specification": 28.02,
         "lower_specification": 28.009,
-        "cp_point": 1.011698921792396,
-        "cpk_point": 0.9731390791507112,
+        "cp_point": 1.012,
+        "cpk_point": 0.973,
         "cp_interval": [
-            0.9358829062365132, 1.0852777599741328
+            0.936, 1.085
         ],
         "cpk_interval": [
-            0.8816835518136438, 1.0664682412434423
-        ]
+            0.882, 1.066
+        ],
+        "error": null
     },
     "file40": {
         "data": [
@@ -671,14 +727,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.005,
         "lower_specification": null,
-        "cp_point": 0.8816344803758978,
-        "cpk_point": 0.8274201703597795,
+        "cp_point": 0.882,
+        "cpk_point": 0.827,
         "cp_interval": [
-            0.7992292514524693, 0.9633988633987001
+            0.799, 0.963
         ],
         "cpk_interval": [
-            0.7238786470234051, 0.943536546912987
-        ]
+            0.724, 0.944
+        ],
+        "error": null
     },
     "file41": {
         "data": [
@@ -688,14 +745,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.005,
         "lower_specification": null,
-        "cp_point": 0.8810954951817181,
-        "cpk_point": 0.8559880312867695,
+        "cp_point": 0.881,
+        "cpk_point": 0.856,
         "cp_interval": [
-            0.7449771773643199, 0.9878270862379801
+            0.745, 0.988
         ],
         "cpk_interval": [
-            0.705825181206256, 0.9842921518319683
-        ]
+            0.706, 0.984
+        ],
+        "error": null
     },
     "file42": {
         "data": [
@@ -705,14 +763,15 @@
         "lower_extreme": null,
         "upper_specification": 28.16,
         "lower_specification": 27.96,
-        "cp_point": 1.2040024286624544,
-        "cpk_point": 1.2025161368861055,
+        "cp_point": 1.204,
+        "cpk_point": 1.203,
         "cp_interval": [
-            1.1058860137415492, 1.263118062154527
+            1.106, 1.263
         ],
         "cpk_interval": [
-            1.0417116516587264, 1.2494845484546413
-        ]
+            1.042, 1.249
+        ],
+        "error": null
     },
     "file43": {
         "data": [
@@ -722,14 +781,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": -6.0,
-        "cp_point": 1.31626036535356,
-        "cpk_point": 1.1677524534161454,
+        "cp_point": 1.316,
+        "cpk_point": 1.168,
         "cp_interval": [
-            1.0442089162248105, 1.558633618016335
+            1.044, 1.559
         ],
         "cpk_interval": [
-            0.9084039200791663, 1.3819376641429841
-        ]
+            0.908, 1.382
+        ],
+        "error": null
     },
     "file44": {
         "data": [
@@ -739,14 +799,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": -6.0,
-        "cp_point": 1.4832622360570284,
-        "cpk_point": 1.127497421879071,
+        "cp_point": 1.483,
+        "cpk_point": 1.127,
         "cp_interval": [
-            1.0940861681383023, 1.67537154643351
+            1.094, 1.675
         ],
         "cpk_interval": [
-            0.7821817315575246, 1.2793337236413524
-        ]
+            0.782, 1.279
+        ],
+        "error": null
     },
     "file45": {
         "data": [
@@ -756,14 +817,15 @@
         "lower_extreme": null,
         "upper_specification": -11.0,
         "lower_specification": -29.0,
-        "cp_point": 1.2105887016722492,
-        "cpk_point": 0.8952327260332028,
+        "cp_point": 1.211,
+        "cpk_point": 0.895,
         "cp_interval": [
-            0.9095872505322934, 1.4766818451233914
+            0.91, 1.477
         ],
         "cpk_interval": [
-            0.6422627788815622, 1.178500997300968
-        ]
+            0.642, 1.179
+        ],
+        "error": null
     },
     "file46": {
         "data": [
@@ -773,14 +835,15 @@
         "lower_extreme": null,
         "upper_specification": -1.0,
         "lower_specification": -19.0,
-        "cp_point": 1.9528474990673044,
-        "cpk_point": 1.923212656164663,
+        "cp_point": 1.953,
+        "cpk_point": 1.923,
         "cp_interval": [
-            1.4784025292819385, 2.361581510277792
+            1.478, 2.362
         ],
         "cpk_interval": [
-            1.381531358029835, 2.311762007690412
-        ]
+            1.382, 2.312
+        ],
+        "error": null
     },
     "file47": {
         "data": [
@@ -790,14 +853,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 1.1053179985148909,
-        "cpk_point": 0.963854168461987,
+        "cp_point": 1.105,
+        "cpk_point": 0.964,
         "cp_interval": [
-            0.780253426989201, 1.4301714813465194
+            0.78, 1.43
         ],
         "cpk_interval": [
-            0.6376447850977279, 1.338359075145036
-        ]
+            0.638, 1.338
+        ],
+        "error": null
     },
     "file48": {
         "data": [
@@ -807,14 +871,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.5010046784943892,
-        "cpk_point": 0.40410863979617856,
+        "cp_point": 1.024,
+        "cpk_point": 0.404,
         "cp_interval": [
-            0.348704300846355, 0.6153645346242593
+            0.713, 1.258
         ],
         "cpk_interval": [
-            0.23333340325269078, 0.5586719506176036
-        ]
+            0.233, 0.559
+        ],
+        "error": null
     },
     "file49": {
         "data": [
@@ -824,14 +889,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.9338891569778751,
-        "cpk_point": 0.7686040228321435,
+        "cp_point": 1.047,
+        "cpk_point": 0.985,
         "cp_interval": [
-            0.6716388220348573, 1.1991334919186154
+            0.753, 1.344
         ],
         "cpk_interval": [
-            0.639370361575916, 0.8428748175309695
-        ]
+            0.664, 1.351
+        ],
+        "error": null
     },
     "file50": {
         "data": [
@@ -841,14 +907,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.0224525424564261,
-        "cpk_point": 0.7624988240624617,
+        "cp_point": 1.148,
+        "cpk_point": 1.129,
         "cp_interval": [
-            0.7809477482950681, 1.2567586192594027
+            0.877, 1.411
         ],
         "cpk_interval": [
-            0.6588450321062056, 0.8387697837992272
-        ]
+            0.806, 1.478
+        ],
+        "error": null
     },
     "file51": {
         "data": [
@@ -858,14 +925,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.069665494315873,
-        "cpk_point": 0.8652514667855642,
+        "cp_point": 1.202,
+        "cpk_point": 1.166,
         "cp_interval": [
-            0.8480610599027633, 1.2622774482343597
+            0.953, 1.418
         ],
         "cpk_interval": [
-            0.7402824377334078, 0.9625989177115447
-        ]
+            0.837, 1.497
+        ],
+        "error": null
     },
     "file52": {
         "data": [
@@ -875,14 +943,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.9202860399910857,
-        "cpk_point": 0.9195848091201375,
+        "cp_point": 0.969,
+        "cpk_point": 0.92,
         "cp_interval": [
-            0.6879919913218748, 1.1529024367435956
+            0.724, 1.214
         ],
         "cpk_interval": [
-            0.6413480439264095, 0.9820168028021051
-        ]
+            0.641, 1.236
+        ],
+        "error": null
     },
     "file53": {
         "data": [
@@ -892,14 +961,15 @@
         "lower_extreme": null,
         "upper_specification": -11.0,
         "lower_specification": -29.0,
-        "cp_point": 0.6098039852511143,
-        "cpk_point": 0.2424263997040357,
+        "cp_point": 0.61,
+        "cpk_point": 0.242,
         "cp_interval": [
-            0.4176714662329569, 0.7768400747301477
+            0.418, 0.777
         ],
         "cpk_interval": [
-            0.11987543513129194, 0.410333185181141
-        ]
+            0.12, 0.41
+        ],
+        "error": null
     },
     "file54": {
         "data": [
@@ -909,14 +979,15 @@
         "lower_extreme": null,
         "upper_specification": -11.0,
         "lower_specification": -29.0,
-        "cp_point": 0.7600890784305171,
-        "cpk_point": -0.11838661347627069,
+        "cp_point": 0.76,
+        "cpk_point": -0.118,
         "cp_interval": [
-            0.5366458490382306, 0.962606536431363
+            0.537, 0.963
         ],
         "cpk_interval": [
-            -0.27318217397548483, -0.0062934473035496565
-        ]
+            -0.273, -0.006
+        ],
+        "error": null
     },
     "file55": {
         "data": [
@@ -926,14 +997,15 @@
         "lower_extreme": null,
         "upper_specification": -1.0,
         "lower_specification": -19.0,
-        "cp_point": 0.8738469652535238,
-        "cpk_point": 0.26393513401563296,
+        "cp_point": 0.874,
+        "cpk_point": 0.264,
         "cp_interval": [
-            0.6159327250501839, 1.1083746282893203
+            0.616, 1.108
         ],
         "cpk_interval": [
-            0.1243969352741734, 0.4279901627444306
-        ]
+            0.124, 0.428
+        ],
+        "error": null
     },
     "file56": {
         "data": [
@@ -943,14 +1015,15 @@
         "lower_extreme": null,
         "upper_specification": -1.0,
         "lower_specification": -19.0,
-        "cp_point": 0.9772220960793718,
-        "cpk_point": 0.7174740913897337,
+        "cp_point": 0.977,
+        "cpk_point": 0.717,
         "cp_interval": [
-            0.6892447059456264, 1.2392912716358209
+            0.689, 1.239
         ],
         "cpk_interval": [
-            0.47290383560552746, 0.9061227334637726
-        ]
+            0.473, 0.906
+        ],
+        "error": null
     },
     "file57": {
         "data": [
@@ -960,14 +1033,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 1.0,
-        "cp_point": 1.3884602328851419,
-        "cpk_point": 1.1791601425296707,
+        "cp_point": 1.388,
+        "cpk_point": 1.179,
         "cp_interval": [
-            1.0308078454714198, 1.719042958034675
+            1.031, 1.719
         ],
         "cpk_interval": [
-            0.8427456809509506, 1.5381934964128672
-        ]
+            0.843, 1.538
+        ],
+        "error": null
     },
     "file58": {
         "data": [
@@ -977,14 +1051,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 1.0,
-        "cp_point": 1.09293263658917,
-        "cpk_point": 0.9716915701830146,
+        "cp_point": 1.093,
+        "cpk_point": 0.972,
         "cp_interval": [
-            0.8596191662120762, 1.2824448749622697
+            0.86, 1.282
         ],
         "cpk_interval": [
-            0.7373477077319799, 1.1397297762604968
-        ]
+            0.737, 1.14
+        ],
+        "error": null
     },
     "file59": {
         "data": [
@@ -994,14 +1069,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.553643364946269,
-        "cpk_point": 0.5337536472181359,
+        "cp_point": 1.554,
+        "cpk_point": 0.534,
         "cp_interval": [
-            1.1133294825829232, 1.7902439288551109
+            1.113, 1.79
         ],
         "cpk_interval": [
-            0.3150137794987598, 0.6527942985952644
-        ]
+            0.315, 0.653
+        ],
+        "error": null
     },
     "file60": {
         "data": [
@@ -1011,14 +1087,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.0472088286356789,
-        "cpk_point": 0.9024482207651432,
+        "cp_point": 1.047,
+        "cpk_point": 0.902,
         "cp_interval": [
-            0.8291272043608606, 1.2416980469872254
+            0.829, 1.242
         ],
         "cpk_interval": [
-            0.719615215164663, 1.0965490754351703
-        ]
+            0.72, 1.097
+        ],
+        "error": null
     },
     "file61": {
         "data": [
@@ -1028,14 +1105,15 @@
         "lower_extreme": null,
         "upper_specification": 11.0,
         "lower_specification": 5.0,
-        "cp_point": 1.996450389920785,
-        "cpk_point": 1.5939589769794373,
+        "cp_point": 1.996,
+        "cpk_point": 1.594,
         "cp_interval": [
-            1.5467478524269058, 2.395520084682755
+            1.547, 2.396
         ],
         "cpk_interval": [
-            1.1872789148968623, 1.9999513774210196
-        ]
+            1.187, 2.0
+        ],
+        "error": null
     },
     "file62": {
         "data": [
@@ -1045,14 +1123,15 @@
         "lower_extreme": null,
         "upper_specification": 11.0,
         "lower_specification": 5.0,
-        "cp_point": 1.715912290910394,
-        "cpk_point": 0.8460127168430073,
+        "cp_point": 1.716,
+        "cpk_point": 0.846,
         "cp_interval": [
-            1.1470716047548117, 2.295102293868169
+            1.147, 2.295
         ],
         "cpk_interval": [
-            0.5410948876529318, 1.2177190739543213
-        ]
+            0.541, 1.218
+        ],
+        "error": null
     },
     "file63": {
         "data": [
@@ -1062,14 +1141,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.63389099342659,
-        "cpk_point": 0.8609882653598978,
+        "cp_point": 1.709,
+        "cpk_point": 1.947,
         "cp_interval": [
-            1.2618314926210499, 1.9980027398687292
+            1.32, 2.089
         ],
         "cpk_interval": [
-            0.7791052566939193, 0.9284661588611413
-        ]
+            1.405, 2.497
+        ],
+        "error": null
     },
     "file64": {
         "data": [
@@ -1079,14 +1159,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.8622447953271823,
-        "cpk_point": 2.156097862617731,
+        "cp_point": 1.862,
+        "cpk_point": 2.156,
         "cp_interval": [
-            1.4226632348298385, 2.2950362167254132
+            1.423, 2.295
         ],
         "cpk_interval": [
-            1.5377957421935347, 2.788993922092561
-        ]
+            1.538, 2.789
+        ],
+        "error": null
     },
     "file65": {
         "data": [
@@ -1096,14 +1177,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 1.1944880299628746,
-        "cpk_point": 0.8914310377474544,
+        "cp_point": 1.292,
+        "cpk_point": 1.323,
         "cp_interval": [
-            0.9352457297356461, 1.4381979191693974
+            1.012, 1.556
         ],
         "cpk_interval": [
-            0.7699888878786967, 0.9744644492029677
-        ]
+            0.945, 1.789
+        ],
+        "error": null
     },
     "file66": {
         "data": [
@@ -1113,14 +1195,15 @@
         "lower_extreme": null,
         "upper_specification": 43.99,
         "lower_specification": 43.74,
-        "cp_point": 1.3515394010829997,
-        "cpk_point": 1.1081691496125363,
+        "cp_point": 1.352,
+        "cpk_point": 1.108,
         "cp_interval": [
-            1.0716676137292143, 1.6102721774784445
+            1.072, 1.61
         ],
         "cpk_interval": [
-            0.8618704974121966, 1.3646029423346424
-        ]
+            0.862, 1.365
+        ],
+        "error": null
     },
     "file67": {
         "data": [
@@ -1130,14 +1213,15 @@
         "lower_extreme": null,
         "upper_specification": 58.55,
         "lower_specification": 58.35,
-        "cp_point": 2.1902944837524454,
-        "cpk_point": 1.9060018126206022,
+        "cp_point": 2.19,
+        "cpk_point": 1.906,
         "cp_interval": [
-            1.605664923105143, 2.5399960051450163
+            1.606, 2.54
         ],
         "cpk_interval": [
-            1.2788108052980673, 2.390502600430197
-        ]
+            1.279, 2.391
+        ],
+        "error": null
     },
     "file68": {
         "data": [
@@ -1147,14 +1231,15 @@
         "lower_extreme": null,
         "upper_specification": 55.005,
         "lower_specification": 54.965,
-        "cp_point": 0.8300259347160066,
-        "cpk_point": 0.7018808527084319,
+        "cp_point": 0.83,
+        "cpk_point": 0.702,
         "cp_interval": [
-            0.6701368152943817, 0.9510035635964608
+            0.67, 0.951
         ],
         "cpk_interval": [
-            0.4959260943110036, 0.8465072002981768
-        ]
+            0.496, 0.847
+        ],
+        "error": null
     },
     "file69": {
         "data": [
@@ -1164,14 +1249,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": 1.0,
-        "cp_point": 2.0051163275946347,
-        "cpk_point": 0.8456331850718056,
+        "cp_point": 2.005,
+        "cpk_point": 0.846,
         "cp_interval": [
-            1.4554815815316826, 2.5057335806336756
+            1.455, 2.506
         ],
         "cpk_interval": [
-            0.5797441454626534, 1.137316514492236
-        ]
+            0.58, 1.137
+        ],
+        "error": null
     },
     "file70": {
         "data": [
@@ -1181,14 +1267,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.7383574781964506,
-        "cpk_point": 0.843428995595698,
+        "cp_point": 1.824,
+        "cpk_point": 2.048,
         "cp_interval": [
-            1.1716885943551283, 2.2981082728777777
+            1.229, 2.411
         ],
         "cpk_interval": [
-            0.721909360336972, 0.9342019947514815
-        ]
+            1.268, 2.869
+        ],
+        "error": null
     },
     "file71": {
         "data": [
@@ -1198,14 +1285,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.986633939584617,
-        "cpk_point": 0.8641657218722265,
+        "cp_point": 2.084,
+        "cpk_point": 2.36,
         "cp_interval": [
-            1.3067362877863593, 2.6616859470391274
+            1.371, 2.793
         ],
         "cpk_interval": [
-            0.7405351591124083, 0.9616645429099621
-        ]
+            1.428, 3.348
+        ],
+        "error": null
     },
     "file72": {
         "data": [
@@ -1215,14 +1303,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 2.282614218854085,
-        "cpk_point": 2.841681389462976,
+        "cp_point": 2.283,
+        "cpk_point": 2.842,
         "cp_interval": [
-            1.4422409261908884, 2.593296210797773
+            1.442, 2.593
         ],
         "cpk_interval": [
-            1.564817729179688, 3.446424157791899
-        ]
+            1.565, 3.446
+        ],
+        "error": null
     },
     "file73": {
         "data": [
@@ -1232,14 +1321,15 @@
         "lower_extreme": null,
         "upper_specification": 94.32,
         "lower_specification": 94.04,
-        "cp_point": 2.578026619668113,
-        "cpk_point": 2.4923056547754716,
+        "cp_point": 2.578,
+        "cpk_point": 2.492,
         "cp_interval": [
-            1.698587397208528, 3.16958590072256
+            1.699, 3.17
         ],
         "cpk_interval": [
-            1.4310029834193925, 2.8875109875988203
-        ]
+            1.431, 2.888
+        ],
+        "error": null
     },
     "file74": {
         "data": [
@@ -1249,14 +1339,15 @@
         "lower_extreme": null,
         "upper_specification": 105.35,
         "lower_specification": 105.2,
-        "cp_point": 0.917542566957882,
-        "cpk_point": 0.6934083046513158,
+        "cp_point": 0.918,
+        "cpk_point": 0.693,
         "cp_interval": [
-            0.6316775553655118, 1.1659244470005046
+            0.632, 1.166
         ],
         "cpk_interval": [
-            0.4353756807155144, 0.8980180115984362
-        ]
+            0.435, 0.898
+        ],
+        "error": null
     },
     "file75": {
         "data": [
@@ -1266,14 +1357,15 @@
         "lower_extreme": null,
         "upper_specification": 103.957,
         "lower_specification": 103.89,
-        "cp_point": 0.9008073721230262,
-        "cpk_point": 0.3262481856267654,
+        "cp_point": 0.901,
+        "cpk_point": 0.326,
         "cp_interval": [
-            0.6544195971579679, 1.1186070069057996
+            0.654, 1.119
         ],
         "cpk_interval": [
-            0.19799323355651355, 0.4880686996732145
-        ]
+            0.198, 0.488
+        ],
+        "error": null
     },
     "file76": {
         "data": [
@@ -1283,14 +1375,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 1.3682445187127892,
-        "cpk_point": 0.5991193868665006,
+        "cp_point": 1.368,
+        "cpk_point": 0.599,
         "cp_interval": [
-            1.0022957782004618, 1.5949006668754466
+            1.002, 1.595
         ],
         "cpk_interval": [
-            0.35419789773464677, 0.7258578672372102
-        ]
+            0.354, 0.726
+        ],
+        "error": null
     },
     "file77": {
         "data": [
@@ -1300,14 +1393,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 1.3886461610401641,
-        "cpk_point": 0.7831315888924504,
+        "cp_point": 1.389,
+        "cpk_point": 0.783,
         "cp_interval": [
-            0.9975626735393243, 1.6122770115005085
+            0.998, 1.612
         ],
         "cpk_interval": [
-            0.4180025654552337, 0.9711363047675189
-        ]
+            0.418, 0.971
+        ],
+        "error": null
     },
     "file78": {
         "data": [
@@ -1317,14 +1411,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 2.775343972379081,
-        "cpk_point": 2.6681539394274676,
+        "cp_point": 2.775,
+        "cpk_point": 2.668,
         "cp_interval": [
-            1.9868410375047143, 3.4951721778730565
+            1.987, 3.495
         ],
         "cpk_interval": [
-            1.8219388388529507, 3.405809954801166
-        ]
+            1.822, 3.406
+        ],
+        "error": null
     },
     "file79": {
         "data": [
@@ -1334,14 +1429,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 2.075095088648294,
-        "cpk_point": 1.6001259205787746,
+        "cp_point": 2.075,
+        "cpk_point": 1.6,
         "cp_interval": [
-            1.5200730167093899, 2.5725208412475054
+            1.52, 2.573
         ],
         "cpk_interval": [
-            1.1888143261278044, 1.976938573758738
-        ]
+            1.189, 1.977
+        ],
+        "error": null
     },
     "file80": {
         "data": [
@@ -1351,14 +1447,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.43937070638140074,
-        "cpk_point": 0.36485890095116325,
+        "cp_point": 0.905,
+        "cpk_point": 0.365,
         "cp_interval": [
-            0.2516072110697419, 0.6294204338970495
+            0.518, 1.296
         ],
         "cpk_interval": [
-            0.18306614275449287, 0.6033947384233148
-        ]
+            0.183, 0.604
+        ],
+        "error": null
     },
     "file81": {
         "data": [
@@ -1368,14 +1465,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.2179959571383408,
-        "cpk_point": 0.14942099430762135,
+        "cp_point": 0.45,
+        "cpk_point": 0.149,
         "cp_interval": [
-            0.07847809456012542, 0.38932656351965783
+            0.162, 0.804
         ],
         "cpk_interval": [
-            0.046863676355438796, 0.3176307088001505
-        ]
+            0.047, 0.318
+        ],
+        "error": null
     },
     "file82": {
         "data": [
@@ -1385,14 +1483,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.5217277235374735,
-        "cpk_point": 0.7400336921057721,
+        "cp_point": 1.707,
+        "cpk_point": 1.753,
         "cp_interval": [
-            0.9070118699319683, 2.1431355127051597
+            1.017, 2.404
         ],
         "cpk_interval": [
-            0.5785751745846549, 0.8511158657556285
-        ]
+            0.958, 2.653
+        ],
+        "error": null
     },
     "file83": {
         "data": [
@@ -1401,7 +1500,16 @@
         "upper_extreme": null,
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
-        "lower_specification": null
+        "lower_specification": null,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More unique values are required to calculate capability indexes."
     },
     "file84": {
         "data": [
@@ -1411,14 +1519,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.976069241868008,
-        "cpk_point": 0.9544545052865785,
+        "cp_point": 2.044,
+        "cpk_point": 2.48,
         "cp_interval": [
-            1.4334207543651187, 2.485064380874708
+            1.483, 2.571
         ],
         "cpk_interval": [
-            0.8407291523501926, 1.0545562359935279
-        ]
+            1.642, 3.294
+        ],
+        "error": null
     },
     "file85": {
         "data": [
@@ -1428,14 +1537,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 2.198969053357894,
-        "cpk_point": 0.9811207069213647,
+        "cp_point": 2.275,
+        "cpk_point": 2.835,
         "cp_interval": [
-            1.6036872925694188, 2.7498783656987937
+            1.659, 2.845
         ],
         "cpk_interval": [
-            0.8541762654353889, 1.0930762996695462
-        ]
+            1.893, 3.73
+        ],
+        "error": null
     },
     "file86": {
         "data": [
@@ -1445,14 +1555,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 2.0664654733862267,
-        "cpk_point": 0.0356835543483946,
+        "cp_point": 2.066,
+        "cpk_point": 0.036,
         "cp_interval": [
-            1.4619292384837304, 2.6103155882937275
+            1.462, 2.61
         ],
         "cpk_interval": [
-            -0.09101694376913207, 0.16262216922531864
-        ]
+            -0.091, 0.163
+        ],
+        "error": null
     },
     "file87": {
         "data": [
@@ -1462,14 +1573,15 @@
         "lower_extreme": null,
         "upper_specification": 11.0,
         "lower_specification": 3.0,
-        "cp_point": 1.632885183850224,
-        "cpk_point": 1.5290404646152844,
+        "cp_point": 1.633,
+        "cpk_point": 1.529,
         "cp_interval": [
-            1.094212885179458, 2.093237603838494
+            1.094, 2.093
         ],
         "cpk_interval": [
-            1.0554690138542628, 1.8366256140511321
-        ]
+            1.055, 1.837
+        ],
+        "error": null
     },
     "file88": {
         "data": [
@@ -1479,14 +1591,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 1.7840977249820729,
-        "cpk_point": -0.5690367374929607,
+        "cp_point": 1.784,
+        "cpk_point": -0.569,
         "cp_interval": [
-            1.2888088581958892, 2.2305441699146904
+            1.289, 2.231
         ],
         "cpk_interval": [
-            -0.7239363176838804, -0.37202992843660215
-        ]
+            -0.724, -0.372
+        ],
+        "error": null
     },
     "file89": {
         "data": [
@@ -1496,14 +1609,15 @@
         "lower_extreme": null,
         "upper_specification": 11.0,
         "lower_specification": 3.0,
-        "cp_point": 1.6164879582150948,
-        "cpk_point": 1.3427005377696684,
+        "cp_point": 1.616,
+        "cpk_point": 1.343,
         "cp_interval": [
-            1.076862716035317, 2.07530833929328
+            1.077, 2.075
         ],
         "cpk_interval": [
-            1.0116103113008459, 1.6271121908420667
-        ]
+            1.012, 1.627
+        ],
+        "error": null
     },
     "file90": {
         "data": [
@@ -1513,14 +1627,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 1.5945132730194056,
-        "cpk_point": 1.487438595527963,
+        "cp_point": 1.595,
+        "cpk_point": 1.487,
         "cp_interval": [
-            1.1311122028415208, 1.9943457019291742
+            1.131, 1.994
         ],
         "cpk_interval": [
-            1.0023587114036345, 1.8861729411624266
-        ]
+            1.002, 1.886
+        ],
+        "error": null
     },
     "file91": {
         "data": [
@@ -1530,14 +1645,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.5398668609298327,
-        "cpk_point": 1.145821654737512,
+        "cp_point": 1.54,
+        "cpk_point": 1.146,
         "cp_interval": [
-            1.1156339612182842, 1.8024706894235698
+            1.116, 1.802
         ],
         "cpk_interval": [
-            0.7473643987627903, 1.501637648559816
-        ]
+            0.747, 1.502
+        ],
+        "error": null
     },
     "file92": {
         "data": [
@@ -1547,14 +1663,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 1.5056792097522713,
-        "cpk_point": -0.561158690356724,
+        "cp_point": 1.506,
+        "cpk_point": -0.561,
         "cp_interval": [
-            1.0811784837728458, 1.8925402649313579
+            1.081, 1.893
         ],
         "cpk_interval": [
-            -0.7043853422243529, -0.36765566243729875
-        ]
+            -0.704, -0.368
+        ],
+        "error": null
     },
     "file93": {
         "data": [
@@ -1564,14 +1681,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.424982869389139,
-        "cpk_point": 1.0602117222959626,
+        "cp_point": 1.425,
+        "cpk_point": 1.06,
         "cp_interval": [
-            0.9276378612338375, 1.8463572548844267
+            0.928, 1.846
         ],
         "cpk_interval": [
-            0.8156072454777894, 1.3046618780445687
-        ]
+            0.816, 1.305
+        ],
+        "error": null
     },
     "file94": {
         "data": [
@@ -1581,14 +1699,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": 1.0,
-        "cp_point": 1.7257505580036037,
-        "cpk_point": 1.139169873246525,
+        "cp_point": 1.726,
+        "cpk_point": 1.139,
         "cp_interval": [
-            1.1550970631748947, 2.2036705544037285
+            1.155, 2.204
         ],
         "cpk_interval": [
-            0.8723952565284098, 1.4000225202978165
-        ]
+            0.872, 1.4
+        ],
+        "error": null
     },
     "file95": {
         "data": [
@@ -1598,14 +1717,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 2.0345020386455475,
-        "cpk_point": 0.7303089039446728,
+        "cp_point": 2.713,
+        "cpk_point": 4.434,
         "cp_interval": [
-            0.6693439400391475, 2.508836080820736
+            0.892, 3.345
         ],
         "cpk_interval": [
-            0.06039486736140496, 0.9377570647775842
-        ]
+            0.858, 7.716
+        ],
+        "error": null
     },
     "file96": {
         "data": [
@@ -1615,14 +1735,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 2.805534613950403,
-        "cpk_point": 0.5370257744035604,
+        "cp_point": 5.611,
+        "cpk_point": 5.333,
         "cp_interval": [
-            1.2473641709995125, 4.152432708144933
+            2.495, 8.305
         ],
         "cpk_interval": [
-            0.07489875883628026, 0.9186937558498128
-        ]
+            2.438, 7.821
+        ],
+        "error": null
     },
     "file97": {
         "data": [
@@ -1632,14 +1753,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 20.0,
         "lower_specification": null,
-        "cp_point": 0.030243221262259166,
-        "cpk_point": -0.11136530894056267,
+        "cp_point": 0.605,
+        "cpk_point": -0.111,
         "cp_interval": [
-            0.004013803666939918, 0.055961695942709416
+            0.08, 1.119
         ],
         "cpk_interval": [
-            -0.2599824386673447, 0.010468416588541765
-        ]
+            -0.255, 0.012
+        ],
+        "error": null
     },
     "file98": {
         "data": [
@@ -1649,14 +1771,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 20.0,
         "lower_specification": null,
-        "cp_point": 0.02713975872968274,
-        "cpk_point": -6.871664242699917,
+        "cp_point": 2.171,
+        "cpk_point": -6.872,
         "cp_interval": [
-            0.007903345583160635, 0.02873673327282258
+            0.632, 2.299
         ],
         "cpk_interval": [
-            -13.127311298043308, -0.025756980692464158
-        ]
+            -13.127, -0.016
+        ],
+        "error": null
     },
     "file99": {
         "data": [
@@ -1666,14 +1789,15 @@
         "lower_extreme": null,
         "upper_specification": 33.85,
         "lower_specification": 33.65,
-        "cp_point": 6.996066222827588,
-        "cpk_point": 0.7961117844878369,
+        "cp_point": 6.996,
+        "cpk_point": 0.796,
         "cp_interval": [
-            2.951824922351031, 10.418746973479736
+            2.952, 10.419
         ],
         "cpk_interval": [
-            0.29173931082313076, 1.22174120102987
-        ]
+            0.292, 1.222
+        ],
+        "error": null
     },
     "file100": {
         "data": [
@@ -1683,14 +1807,15 @@
         "lower_extreme": null,
         "upper_specification": 31.7,
         "lower_specification": 31.45,
-        "cp_point": 2.0099257424664687,
-        "cpk_point": -3.8591633830332635,
+        "cp_point": 2.01,
+        "cpk_point": -3.859,
         "cp_interval": [
-            0.829246466610303, 3.022819722124263
+            0.829, 3.023
         ],
         "cpk_interval": [
-            -5.844233785433732, -1.5410313333781902
-        ]
+            -5.844, -1.541
+        ],
+        "error": null
     },
     "file101": {
         "data": [
@@ -1700,14 +1825,15 @@
         "lower_extreme": null,
         "upper_specification": 30.31,
         "lower_specification": 30.29,
-        "cp_point": 0.5314775994332225,
-        "cpk_point": 0.21786529218946432,
+        "cp_point": 0.531,
+        "cpk_point": 0.218,
         "cp_interval": [
-            0.05521726111814324, 0.710605617390545
+            0.055, 0.711
         ],
         "cpk_interval": [
-            -0.27021843838814663, 0.5679689137135614
-        ]
+            -0.27, 0.568
+        ],
+        "error": null
     },
     "file102": {
         "data": [
@@ -1717,14 +1843,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 50.0,
         "lower_specification": null,
-        "cp_point": 2.876561739531469,
-        "cpk_point": 0.641147346129078,
+        "cp_point": 4.495,
+        "cpk_point": 3.962,
         "cp_interval": [
-            0.5443979931338394, 3.3885529212168812
+            0.851, 5.295
         ],
         "cpk_interval": [
-            0.06700164384463324, 1.003962679020457
-        ]
+            0.559, 11.757
+        ],
+        "error": null
     },
     "file103": {
         "data": [
@@ -1734,14 +1861,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 14.0,
         "lower_specification": null,
-        "cp_point": 2.0624518401271867,
-        "cpk_point": 0.5852064240517311,
+        "cp_point": 5.589,
+        "cpk_point": 4.454,
         "cp_interval": [
-            0.37793228302813187, 2.691630294702622
+            1.024, 7.293
         ],
         "cpk_interval": [
-            -0.04236071643119481, 0.8321691964313535
-        ]
+            0.952, 7.539
+        ],
+        "error": null
     },
     "file104": {
         "data": [
@@ -1751,14 +1879,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 14.0,
         "lower_specification": null,
-        "cp_point": 2.1751736825953407,
-        "cpk_point": 0.5439904448563743,
+        "cp_point": 7.082,
+        "cpk_point": 3.017,
         "cp_interval": [
-            8.598465529613761e-22, 2.7163180726895257
+            0.0, 8.844
         ],
         "cpk_interval": [
-            8.033567603026234e-22, 0.8883849113392439
-        ]
+            0.0, 5.05
+        ],
+        "error": null
     },
     "file105": {
         "data": [
@@ -1768,14 +1897,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": -6.0,
-        "cp_point": 2.0469543932724137,
-        "cpk_point": 1.1443504625886889,
+        "cp_point": 2.047,
+        "cpk_point": 1.144,
         "cp_interval": [
-            1.6019332719768802, 2.429823864471144
+            1.602, 2.43
         ],
         "cpk_interval": [
-            0.8644903554030785, 1.3696792574581185
-        ]
+            0.864, 1.37
+        ],
+        "error": null
     },
     "file106": {
         "data": [
@@ -1785,14 +1915,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": -6.0,
-        "cp_point": 1.8672664826067948,
-        "cpk_point": 1.8268896194079904,
+        "cp_point": 1.867,
+        "cpk_point": 1.827,
         "cp_interval": [
-            1.4372581829976865, 2.2477601594237706
+            1.437, 2.248
         ],
         "cpk_interval": [
-            1.346639917323925, 2.192183582218713
-        ]
+            1.347, 2.192
+        ],
+        "error": null
     },
     "file107": {
         "data": [
@@ -1802,14 +1933,15 @@
         "lower_extreme": null,
         "upper_specification": -6.0,
         "lower_specification": -24.0,
-        "cp_point": 1.2286054955109746,
-        "cpk_point": 1.1025004495085269,
+        "cp_point": 1.229,
+        "cpk_point": 1.103,
         "cp_interval": [
-            1.0478639364430675, 1.3578944803647166
+            1.048, 1.358
         ],
         "cpk_interval": [
-            0.8589322187810322, 1.3017702796819486
-        ]
+            0.859, 1.302
+        ],
+        "error": null
     },
     "file108": {
         "data": [
@@ -1819,14 +1951,15 @@
         "lower_extreme": null,
         "upper_specification": -6.0,
         "lower_specification": -24.0,
-        "cp_point": 1.8586064031857206,
-        "cpk_point": 1.5813181200901494,
+        "cp_point": 1.859,
+        "cpk_point": 1.581,
         "cp_interval": [
-            1.4229499460684474, 2.235018506679514
+            1.423, 2.235
         ],
         "cpk_interval": [
-            1.1572823631999367, 1.9227017569690306
-        ]
+            1.157, 1.923
+        ],
+        "error": null
     },
     "file109": {
         "data": [
@@ -1836,14 +1969,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.9396086341960299,
-        "cpk_point": 0.8598957006294281,
+        "cp_point": 1.158,
+        "cpk_point": 1.038,
         "cp_interval": [
-            0.8285152873673018, 1.0690329374231347
+            1.021, 1.318
         ],
         "cpk_interval": [
-            0.7151691006563318, 0.9610095348371981
-        ]
+            0.809, 1.263
+        ],
+        "error": null
     },
     "file110": {
         "data": [
@@ -1853,14 +1987,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.1011568416329438,
-        "cpk_point": 0.8929244017643968,
+        "cp_point": 1.149,
+        "cpk_point": 1.147,
         "cp_interval": [
-            0.7530249811003549, 1.473180852251314
+            0.786, 1.537
         ],
         "cpk_interval": [
-            0.740104955640166, 0.9539256349829612
-        ]
+            0.74, 1.622
+        ],
+        "error": null
     },
     "file111": {
         "data": [
@@ -1870,14 +2005,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.5871863418293294,
-        "cpk_point": 0.4762054873033266,
+        "cp_point": 0.783,
+        "cpk_point": 0.476,
         "cp_interval": [
-            0.40277648167666513, 0.8296605595407317
+            0.537, 1.106
         ],
         "cpk_interval": [
-            0.27198418587536477, 0.7212277159482625
-        ]
+            0.272, 0.738
+        ],
+        "error": null
     },
     "file112": {
         "data": [
@@ -1887,14 +2023,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.031449872086045,
-        "cpk_point": 0.9057998815852151,
+        "cp_point": 1.082,
+        "cpk_point": 1.059,
         "cp_interval": [
-            0.6987384503403302, 1.3874054483529459
+            0.733, 1.456
         ],
         "cpk_interval": [
-            0.6767292608935492, 0.9644127336009872
-        ]
+            0.677, 1.509
+        ],
+        "error": null
     },
     "file113": {
         "data": [
@@ -1904,14 +2041,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 0.6655498191521955,
-        "cpk_point": 0.6149168177181974,
+        "cp_point": 0.697,
+        "cpk_point": 0.615,
         "cp_interval": [
-            0.4430866900696329, 0.9085784324757882
+            0.464, 0.952
         ],
         "cpk_interval": [
-            0.3869037251459181, 0.900924134810215
-        ]
+            0.387, 0.901
+        ],
+        "error": null
     },
     "file114": {
         "data": [
@@ -1921,14 +2059,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.0747321519973658,
-        "cpk_point": 0.7542096865636942,
+        "cp_point": 1.556,
+        "cpk_point": 1.305,
         "cp_interval": [
-            0.8585227675048668, 1.2520605762652555
+            1.243, 1.812
         ],
         "cpk_interval": [
-            0.5558918838106363, 0.8867153614129591
-        ]
+            1.014, 1.605
+        ],
+        "error": null
     },
     "file115": {
         "data": [
@@ -1938,14 +2077,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.2811104509998055,
-        "cpk_point": 0.698814487835174,
+        "cp_point": 1.846,
+        "cpk_point": 1.583,
         "cp_interval": [
-            0.8800165524918377, 1.4876339646913637
+            1.268, 2.144
         ],
         "cpk_interval": [
-            0.5340658172691694, 0.8269689995275157
-        ]
+            0.966, 1.882
+        ],
+        "error": null
     },
     "file116": {
         "data": [
@@ -1955,14 +2095,15 @@
         "lower_extreme": null,
         "upper_specification": 56.56,
         "lower_specification": 56.31,
-        "cp_point": 1.466838240586239,
-        "cpk_point": 1.222413849050923,
+        "cp_point": 1.467,
+        "cpk_point": 1.222,
         "cp_interval": [
-            1.0947873230910214, 1.6861179132752344
+            1.095, 1.686
         ],
         "cpk_interval": [
-            0.9857944272944001, 1.4218930664743759
-        ]
+            0.986, 1.422
+        ],
+        "error": null
     },
     "file117": {
         "data": [
@@ -1972,14 +2113,15 @@
         "lower_extreme": null,
         "upper_specification": 71.05,
         "lower_specification": 70.85,
-        "cp_point": 1.4410615522952563,
-        "cpk_point": 1.161614893630738,
+        "cp_point": 1.441,
+        "cpk_point": 1.162,
         "cp_interval": [
-            1.1508520163273117, 1.7020076106835527
+            1.151, 1.702
         ],
         "cpk_interval": [
-            0.915277678307539, 1.3642462216514148
-        ]
+            0.915, 1.364
+        ],
+        "error": null
     },
     "file118": {
         "data": [
@@ -1989,14 +2131,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.9132811961550826,
-        "cpk_point": 0.9031487903628856,
+        "cp_point": 0.961,
+        "cpk_point": 0.903,
         "cp_interval": [
-            0.6433608777535907, 1.1944071227483692
+            0.677, 1.257
         ],
         "cpk_interval": [
-            0.5981593438886728, 1.0145258886567048
-        ]
+            0.598, 1.261
+        ],
+        "error": null
     },
     "file119": {
         "data": [
@@ -2006,14 +2149,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.7301552280145439,
-        "cpk_point": 0.7204522704319114,
+        "cp_point": 0.818,
+        "cpk_point": 0.72,
         "cp_interval": [
-            0.46850936649209435, 1.0151073140858664
+            0.525, 1.137
         ],
         "cpk_interval": [
-            0.4359915863061454, 0.8328519348139544
-        ]
+            0.436, 1.073
+        ],
+        "error": null
     },
     "file120": {
         "data": [
@@ -2023,14 +2167,15 @@
         "lower_extreme": null,
         "upper_specification": 67.419,
         "lower_specification": 67.369,
-        "cp_point": 0.8559882059641565,
-        "cpk_point": 0.851865001619216,
+        "cp_point": 0.856,
+        "cpk_point": 0.852,
         "cp_interval": [
-            0.6390636940412971, 0.9919125430288149
+            0.639, 0.992
         ],
         "cpk_interval": [
-            0.5712086420510297, 0.9295908024901324
-        ]
+            0.571, 0.93
+        ],
+        "error": null
     },
     "file121": {
         "data": [
@@ -2040,14 +2185,15 @@
         "lower_extreme": null,
         "upper_specification": 67.419,
         "lower_specification": 67.369,
-        "cp_point": 0.8543231404601296,
-        "cpk_point": 0.7700344891465246,
+        "cp_point": 0.854,
+        "cpk_point": 0.77,
         "cp_interval": [
-            0.6398893732870101, 0.9842948142428389
+            0.64, 0.984
         ],
         "cpk_interval": [
-            0.5934438868597244, 0.8977421750624617
-        ]
+            0.593, 0.898
+        ],
+        "error": null
     },
     "file122": {
         "data": [
@@ -2057,14 +2203,15 @@
         "lower_extreme": null,
         "upper_specification": 67.419,
         "lower_specification": 67.369,
-        "cp_point": 0.8450604248697233,
-        "cpk_point": 0.8140390557664432,
+        "cp_point": 0.845,
+        "cpk_point": 0.814,
         "cp_interval": [
-            0.6286783121118569, 0.9773240597265063
+            0.629, 0.977
         ],
         "cpk_interval": [
-            0.5484279858974048, 0.9489540303870766
-        ]
+            0.548, 0.949
+        ],
+        "error": null
     },
     "file123": {
         "data": [
@@ -2074,14 +2221,15 @@
         "lower_extreme": null,
         "upper_specification": -6.0,
         "lower_specification": -24.0,
-        "cp_point": 0.8840383070693689,
-        "cpk_point": 0.693587144639876,
+        "cp_point": 0.884,
+        "cpk_point": 0.694,
         "cp_interval": [
-            0.740987695807567, 1.0156197588034537
+            0.741, 1.016
         ],
         "cpk_interval": [
-            0.5143333655088549, 0.8639243218540782
-        ]
+            0.514, 0.864
+        ],
+        "error": null
     },
     "file124": {
         "data": [
@@ -2091,14 +2239,15 @@
         "lower_extreme": null,
         "upper_specification": -6.0,
         "lower_specification": -24.0,
-        "cp_point": 0.9382398811569638,
-        "cpk_point": 0.6147080444749199,
+        "cp_point": 0.938,
+        "cpk_point": 0.615,
         "cp_interval": [
-            0.7549787665542926, 1.0711734758322469
+            0.755, 1.071
         ],
         "cpk_interval": [
-            0.4137068264500746, 0.721469945673121
-        ]
+            0.414, 0.721
+        ],
+        "error": null
     },
     "file125": {
         "data": [
@@ -2108,14 +2257,15 @@
         "lower_extreme": null,
         "upper_specification": -6.0,
         "lower_specification": -24.0,
-        "cp_point": 1.3626926061664886,
-        "cpk_point": 0.8634733629055417,
+        "cp_point": 1.363,
+        "cpk_point": 0.863,
         "cp_interval": [
-            0.9971334526781602, 1.5489295678332706
+            0.997, 1.549
         ],
         "cpk_interval": [
-            0.568043775121705, 1.0219566318591629
-        ]
+            0.568, 1.022
+        ],
+        "error": null
     },
     "file126": {
         "data": [
@@ -2125,14 +2275,15 @@
         "lower_extreme": null,
         "upper_specification": -6.0,
         "lower_specification": -24.0,
-        "cp_point": 1.0367970349439408,
-        "cpk_point": 0.4023603652029003,
+        "cp_point": 1.037,
+        "cpk_point": 0.402,
         "cp_interval": [
-            0.82429349540202, 1.22733163028828
+            0.824, 1.227
         ],
         "cpk_interval": [
-            0.2993549970411006, 0.5289515980105682
-        ]
+            0.299, 0.529
+        ],
+        "error": null
     },
     "file127": {
         "data": [
@@ -2142,14 +2293,15 @@
         "lower_extreme": null,
         "upper_specification": 11.0,
         "lower_specification": 3.0,
-        "cp_point": 1.41021792043802,
-        "cpk_point": 0.4766422946259221,
+        "cp_point": 1.41,
+        "cpk_point": 0.477,
         "cp_interval": [
-            1.129573319583323, 1.6702585022434524
+            1.13, 1.67
         ],
         "cpk_interval": [
-            0.3569868255528975, 0.6204217414310839
-        ]
+            0.357, 0.62
+        ],
+        "error": null
     },
     "file128": {
         "data": [
@@ -2159,14 +2311,15 @@
         "lower_extreme": null,
         "upper_specification": 11.0,
         "lower_specification": 3.0,
-        "cp_point": 1.42412958740148,
-        "cpk_point": 0.040823361246833174,
+        "cp_point": 1.424,
+        "cpk_point": 0.041,
         "cp_interval": [
-            1.133809517150024, 1.6914284196825595
+            1.134, 1.691
         ],
         "cpk_interval": [
-            -0.025993892606821434, 0.1277864836222955
-        ]
+            -0.026, 0.128
+        ],
+        "error": null
     },
     "file129": {
         "data": [
@@ -2176,14 +2329,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.1385356650541043,
-        "cpk_point": 0.8392128218762056,
+        "cp_point": 1.139,
+        "cpk_point": 0.839,
         "cp_interval": [
-            0.9003563621133012, 1.3561410689967612
+            0.9, 1.356
         ],
         "cpk_interval": [
-            0.6404452634412399, 1.0592077928983898
-        ]
+            0.64, 1.059
+        ],
+        "error": null
     },
     "file130": {
         "data": [
@@ -2193,14 +2347,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.5450687373815104,
-        "cpk_point": 1.4447177149588253,
+        "cp_point": 1.545,
+        "cpk_point": 1.445,
         "cp_interval": [
-            1.2323660382588124, 1.8238689793381115
+            1.232, 1.824
         ],
         "cpk_interval": [
-            1.122952929982453, 1.710179165046007
-        ]
+            1.123, 1.71
+        ],
+        "error": null
     },
     "file131": {
         "data": [
@@ -2210,14 +2365,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": 2.0,
-        "cp_point": 1.5995299059350525,
-        "cpk_point": 1.172761413740237,
+        "cp_point": 1.6,
+        "cpk_point": 1.173,
         "cp_interval": [
-            1.1438849977831973, 1.8079841222503203
+            1.144, 1.808
         ],
         "cpk_interval": [
-            0.9569697827683835, 1.4154569034934512
-        ]
+            0.957, 1.415
+        ],
+        "error": null
     },
     "file132": {
         "data": [
@@ -2227,14 +2383,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": 2.0,
-        "cp_point": 0.8014809135606936,
-        "cpk_point": 0.7440763471388286,
+        "cp_point": 0.801,
+        "cpk_point": 0.744,
         "cp_interval": [
-            0.6403081346681877, 0.9497607613454718
+            0.64, 0.95
         ],
         "cpk_interval": [
-            0.5757568502837036, 0.8680425268313648
-        ]
+            0.576, 0.868
+        ],
+        "error": null
     },
     "file133": {
         "data": [
@@ -2244,14 +2401,15 @@
         "lower_extreme": null,
         "upper_specification": 31.7,
         "lower_specification": 31.6,
-        "cp_point": 1.2084478090961694,
-        "cpk_point": -4.2394117584127615,
+        "cp_point": 1.208,
+        "cpk_point": -4.239,
         "cp_interval": [
-            0.6355122107658993, 1.652298634042056
+            0.636, 1.652
         ],
         "cpk_interval": [
-            -6.096816267183483, -2.0898592703604746
-        ]
+            -6.097, -2.09
+        ],
+        "error": null
     },
     "file134": {
         "data": [
@@ -2261,14 +2419,15 @@
         "lower_extreme": null,
         "upper_specification": 30.183,
         "lower_specification": 30.113,
-        "cp_point": 0.5792994096571993,
-        "cpk_point": 0.07665575113567205,
+        "cp_point": 0.579,
+        "cpk_point": 0.077,
         "cp_interval": [
-            0.0848811380835325, 0.780578870282726
+            0.085, 0.781
         ],
         "cpk_interval": [
-            -0.2953183560151041, 0.14669281692317404
-        ]
+            -0.295, 0.147
+        ],
+        "error": null
     },
     "file135": {
         "data": [
@@ -2278,14 +2437,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 10.0,
         "lower_specification": null,
-        "cp_point": 1.7014510370998341,
-        "cpk_point": 0.7768719971100625,
+        "cp_point": 2.431,
+        "cpk_point": 2.13,
         "cp_interval": [
-            0.16596203123156367, 2.004701941298526
+            0.237, 2.864
         ],
         "cpk_interval": [
-            0.12917761039182646, 1.1137054635202956
-        ]
+            0.129, 3.19
+        ],
+        "error": null
     },
     "file136": {
         "data": [
@@ -2295,14 +2455,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 10.0,
         "lower_specification": null,
-        "cp_point": 0.4039081224204452,
-        "cpk_point": 0.3682755656908173,
+        "cp_point": 0.577,
+        "cpk_point": 0.368,
         "cp_interval": [
-            0.001373144243831331, 1.1364202504438974
+            0.002, 1.623
         ],
         "cpk_interval": [
-            0.0011331632964988365, 0.820903310407674
-        ]
+            0.001, 1.241
+        ],
+        "error": null
     },
     "file137": {
         "data": [
@@ -2312,14 +2473,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.1976221101982156,
-        "cpk_point": 0.6176818301991153,
+        "cp_point": 1.916,
+        "cpk_point": 1.677,
         "cp_interval": [
-            0.6659102976239349, 1.6231091907408266
+            1.065, 2.597
         ],
         "cpk_interval": [
-            0.29114521763273704, 0.9030006225816721
-        ]
+            0.858, 2.439
+        ],
+        "error": null
     },
     "file138": {
         "data": [
@@ -2329,14 +2491,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 0.6070134908627489,
-        "cpk_point": 0.5522332204755671,
+        "cp_point": 1.34,
+        "cpk_point": 0.62,
         "cp_interval": [
-            0.030366820484407656, 1.2492288241721639
+            0.067, 2.757
         ],
         "cpk_interval": [
-            0.025638745004860915, 0.7716845253017454
-        ]
+            0.026, 1.54
+        ],
+        "error": null
     },
     "file139": {
         "data": [
@@ -2346,14 +2509,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 20.0,
         "lower_specification": null,
-        "cp_point": 0.005516779784425856,
-        "cpk_point": -0.46731178677660257,
+        "cp_point": 0.331,
+        "cpk_point": -0.467,
         "cp_interval": [
-            0.00254816648848743, 0.00824311168335223
+            0.153, 0.495
         ],
         "cpk_interval": [
-            -0.7408925745300985, -0.16444440296025775
-        ]
+            -0.741, -0.164
+        ],
+        "error": null
     },
     "file140": {
         "data": [
@@ -2363,14 +2527,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 20.0,
         "lower_specification": null,
-        "cp_point": 0.0044909396492155,
-        "cpk_point": -0.423749510799355,
+        "cp_point": 0.269,
+        "cpk_point": -0.424,
         "cp_interval": [
-            0.0024341800135693715, 0.006899788877579145
+            0.146, 0.414
         ],
         "cpk_interval": [
-            -0.6754393513011772, -0.14469417700721696
-        ]
+            -0.675, -0.145
+        ],
+        "error": null
     },
     "file141": {
         "data": [
@@ -2380,14 +2545,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 50.0,
         "lower_specification": null,
-        "cp_point": 0.5532245087289748,
-        "cpk_point": 0.5330420215944764,
+        "cp_point": 0.922,
+        "cpk_point": 0.533,
         "cp_interval": [
-            0.30931049033658575, 0.7592507947314884
+            0.516, 1.265
         ],
         "cpk_interval": [
-            0.2115385700968126, 0.6811585680740013
-        ]
+            0.241, 0.869
+        ],
+        "error": null
     },
     "file142": {
         "data": [
@@ -2397,14 +2563,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 4.385287728404003,
-        "cpk_point": 2.2505842272881447,
+        "cp_point": 4.385,
+        "cpk_point": 2.251,
         "cp_interval": [
-            0.8975639204702365, 7.125518981483558
+            0.898, 7.126
         ],
         "cpk_interval": [
-            0.6610551712557554, 3.6147362730994543
-        ]
+            0.661, 3.615
+        ],
+        "error": null
     },
     "file143": {
         "data": [
@@ -2414,14 +2581,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 4.446201023360837,
-        "cpk_point": 1.582825654493686,
+        "cp_point": 4.446,
+        "cpk_point": 1.583,
         "cp_interval": [
-            0.9263315673546759, 7.205234880511305
+            0.926, 7.205
         ],
         "cpk_interval": [
-            0.4079033193773559, 2.674672966842542
-        ]
+            0.408, 2.675
+        ],
+        "error": null
     },
     "file144": {
         "data": [
@@ -2431,14 +2599,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.6184565853753976,
-        "cpk_point": 0.7200247836805045,
+        "cp_point": 2.618,
+        "cpk_point": 0.72,
         "cp_interval": [
-            0.7425866656514284, 4.327524476844363
+            0.743, 4.328
         ],
         "cpk_interval": [
-            0.06344776983450369, 1.3306352874553238
-        ]
+            0.063, 1.331
+        ],
+        "error": null
     },
     "file145": {
         "data": [
@@ -2448,14 +2617,15 @@
         "lower_extreme": null,
         "upper_specification": 12.0,
         "lower_specification": 4.0,
-        "cp_point": 2.753737632190611,
-        "cpk_point": 1.7014657389753283,
+        "cp_point": 2.754,
+        "cpk_point": 1.701,
         "cp_interval": [
-            1.8781490934028429, 3.549380401227773
+            1.878, 3.549
         ],
         "cpk_interval": [
-            1.1017323255145304, 2.2753543265546523
-        ]
+            1.102, 2.275
+        ],
+        "error": null
     },
     "file146": {
         "data": [
@@ -2465,14 +2635,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 3.3077575715282097,
-        "cpk_point": 1.1578157284410635,
+        "cp_point": 3.308,
+        "cpk_point": 1.158,
         "cp_interval": [
-            0.9068379456473425, 5.53719043919296
+            0.907, 5.537
         ],
         "cpk_interval": [
-            0.1911235940940073, 2.1540866961989655
-        ]
+            0.191, 2.154
+        ],
+        "error": null
     },
     "file147": {
         "data": [
@@ -2481,7 +2652,16 @@
         "upper_extreme": null,
         "lower_extreme": null,
         "upper_specification": 20.0,
-        "lower_specification": 10.0
+        "lower_specification": 10.0,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More unique values are required to calculate capability indexes."
     },
     "file148": {
         "data": [
@@ -2490,7 +2670,16 @@
         "upper_extreme": null,
         "lower_extreme": null,
         "upper_specification": 5.0,
-        "lower_specification": 1.0
+        "lower_specification": 1.0,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More unique values are required to calculate capability indexes."
     },
     "file149": {
         "data": [
@@ -2500,14 +2689,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 2.9969341278598947,
-        "cpk_point": 1.9703268709607935,
+        "cp_point": 2.997,
+        "cpk_point": 1.97,
         "cp_interval": [
-            2.168960562690276, 3.6734840746004007
+            2.169, 3.673
         ],
         "cpk_interval": [
-            1.2882637074015326, 2.7469119160553945
-        ]
+            1.288, 2.747
+        ],
+        "error": null
     },
     "file150": {
         "data": [
@@ -2516,7 +2706,16 @@
         "upper_extreme": null,
         "lower_extreme": null,
         "upper_specification": 5.0,
-        "lower_specification": 1.0
+        "lower_specification": 1.0,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More unique values are required to calculate capability indexes."
     },
     "file151": {
         "data": [
@@ -2526,14 +2725,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 2.712947391931854,
-        "cpk_point": 2.159834084932701,
+        "cp_point": 2.713,
+        "cpk_point": 2.16,
         "cp_interval": [
-            1.7658578700200394, 3.506830986362562
+            1.766, 3.507
         ],
         "cpk_interval": [
-            1.5562169276775533, 2.7085102270145267
-        ]
+            1.556, 2.709
+        ],
+        "error": null
     },
     "file152": {
         "data": [
@@ -2543,14 +2743,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 1.0,
-        "cp_point": 2.062646690097341,
-        "cpk_point": 1.6142240343941867,
+        "cp_point": 2.063,
+        "cpk_point": 1.614,
         "cp_interval": [
-            1.3662214236398191, 2.674408779912407
+            1.366, 2.674
         ],
         "cpk_interval": [
-            1.002482537984361, 2.2210227523526367
-        ]
+            1.002, 2.221
+        ],
+        "error": null
     },
     "file153": {
         "data": [
@@ -2560,14 +2761,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 2.240319819359104,
-        "cpk_point": 1.1754504336430425,
+        "cp_point": 2.24,
+        "cpk_point": 1.175,
         "cp_interval": [
-            1.5219785274176976, 2.8954017690116194
+            1.522, 2.895
         ],
         "cpk_interval": [
-            0.7529749660692099, 1.610406043572869
-        ]
+            0.753, 1.61
+        ],
+        "error": null
     },
     "file154": {
         "data": [
@@ -2577,14 +2779,15 @@
         "lower_extreme": null,
         "upper_specification": 18.0,
         "lower_specification": 12.0,
-        "cp_point": 2.2074466034702596,
-        "cpk_point": 1.9077883330269692,
+        "cp_point": 2.207,
+        "cpk_point": 1.908,
         "cp_interval": [
-            1.408583645990822, 2.8813816305667075
+            1.409, 2.881
         ],
         "cpk_interval": [
-            1.3583791361046973, 2.3736209686513985
-        ]
+            1.358, 2.374
+        ],
+        "error": null
     },
     "file155": {
         "data": [
@@ -2594,14 +2797,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 2.3291088604067416,
-        "cpk_point": 1.3659829122869518,
+        "cp_point": 2.329,
+        "cpk_point": 1.366,
         "cp_interval": [
-            1.5802212936380835, 3.0095653970317784
+            1.58, 3.01
         ],
         "cpk_interval": [
-            0.8743601356216183, 1.8575496535577518
-        ]
+            0.874, 1.858
+        ],
+        "error": null
     },
     "file156": {
         "data": [
@@ -2611,14 +2815,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 3.185567943703844,
-        "cpk_point": 0.8837884450008797,
+        "cp_point": 3.324,
+        "cpk_point": 4.891,
         "cp_interval": [
-            2.2853938037507806, 3.8163266129763467
+            2.385, 3.982
         ],
         "cpk_interval": [
-            0.7004654715148355, 0.9933220175588054
-        ]
+            2.762, 6.513
+        ],
+        "error": null
     },
     "file157": {
         "data": [
@@ -2628,14 +2833,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 3.273320789060741,
-        "cpk_point": 0.7923917400812398,
+        "cp_point": 3.423,
+        "cpk_point": 4.566,
         "cp_interval": [
-            2.2820344113475657, 4.1817141695109035
+            2.386, 4.373
         ],
         "cpk_interval": [
-            0.6283871287206159, 0.917834859697712
-        ]
+            2.876, 6.075
+        ],
+        "error": null
     },
     "file158": {
         "data": [
@@ -2645,14 +2851,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 1.5332529524468532,
-        "cpk_point": 0.827302239856853,
+        "cp_point": 1.687,
+        "cpk_point": 2.001,
         "cp_interval": [
-            1.0970731528625286, 1.9189602056525348
+            1.207, 2.111
         ],
         "cpk_interval": [
-            0.6779522613390065, 0.9618872792988381
-        ]
+            1.287, 2.663
+        ],
+        "error": null
     },
     "file159": {
         "data": [
@@ -2662,14 +2869,15 @@
         "lower_extreme": null,
         "upper_specification": 42.2,
         "lower_specification": 41.95,
-        "cp_point": 2.668609006467489,
-        "cpk_point": 1.4686344149569732,
+        "cp_point": 2.669,
+        "cpk_point": 1.469,
         "cp_interval": [
-            1.822473249351896, 3.4362468861440503
+            1.822, 3.436
         ],
         "cpk_interval": [
-            0.9522461035194058, 1.974398003402826
-        ]
+            0.952, 1.974
+        ],
+        "error": null
     },
     "file160": {
         "data": [
@@ -2679,14 +2887,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.104817055306466,
-        "cpk_point": 0.863379339712229,
+        "cp_point": 2.105,
+        "cpk_point": 0.863,
         "cp_interval": [
-            1.2268578163825672, 2.777776121024447
+            1.227, 2.778
         ],
         "cpk_interval": [
-            0.6029001160321075, 1.1091453479666509
-        ]
+            0.603, 1.109
+        ],
+        "error": null
     },
     "file161": {
         "data": [
@@ -2696,14 +2905,15 @@
         "lower_extreme": null,
         "upper_specification": 51.8,
         "lower_specification": 51.65,
-        "cp_point": 2.332987348610613,
-        "cpk_point": 2.2920307439427243,
+        "cp_point": 2.333,
+        "cpk_point": 2.292,
         "cp_interval": [
-            1.5348596676353865, 3.042837715726549
+            1.535, 3.043
         ],
         "cpk_interval": [
-            1.4141197783122599, 2.9533713541483526
-        ]
+            1.414, 2.953
+        ],
+        "error": null
     },
     "file162": {
         "data": [
@@ -2713,14 +2923,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.0506369888575757,
-        "cpk_point": 0.9143273749191749,
+        "cp_point": 2.051,
+        "cpk_point": 0.914,
         "cp_interval": [
-            1.359457252411191, 2.627602130730694
+            1.359, 2.628
         ],
         "cpk_interval": [
-            0.6079246328937578, 1.2016652672079358
-        ]
+            0.608, 1.202
+        ],
+        "error": null
     },
     "file163": {
         "data": [
@@ -2730,14 +2941,15 @@
         "lower_extreme": null,
         "upper_specification": 50.876,
         "lower_specification": 50.819,
-        "cp_point": 0.9322000993177727,
-        "cpk_point": 0.4112404147366328,
+        "cp_point": 0.932,
+        "cpk_point": 0.411,
         "cp_interval": [
-            0.6350530229094742, 1.2072073310760245
+            0.635, 1.207
         ],
         "cpk_interval": [
-            0.20726954423225247, 0.5659823766525621
-        ]
+            0.207, 0.566
+        ],
+        "error": null
     },
     "file164": {
         "data": [
@@ -2747,14 +2959,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.3677850747260325,
-        "cpk_point": 0.8558418698986474,
+        "cp_point": 2.368,
+        "cpk_point": 0.856,
         "cp_interval": [
-            1.4159686270152045, 3.0913175234221915
+            1.416, 3.091
         ],
         "cpk_interval": [
-            0.5950560121390358, 1.1030209954134762
-        ]
+            0.595, 1.103
+        ],
+        "error": null
     },
     "file165": {
         "data": [
@@ -2764,14 +2977,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 3.4559590306812566,
-        "cpk_point": 0.8599535471673482,
+        "cp_point": 3.456,
+        "cpk_point": 0.86,
         "cp_interval": [
-            1.8749893896738035, 4.101150424881556
+            1.875, 4.101
         ],
         "cpk_interval": [
-            0.5134114486717444, 1.1279912662457277
-        ]
+            0.513, 1.128
+        ],
+        "error": null
     },
     "file166": {
         "data": [
@@ -2781,14 +2995,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.665885198894911,
-        "cpk_point": 2.17957094191825,
+        "cp_point": 2.666,
+        "cpk_point": 2.18,
         "cp_interval": [
-            0.0020782970462103873, 3.658259662111884
+            0.002, 3.658
         ],
         "cpk_interval": [
-            0.0015935426867406677, 2.5790665730508753
-        ]
+            0.002, 2.579
+        ],
+        "error": null
     },
     "file167": {
         "data": [
@@ -2798,14 +3013,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 3.113694298084129,
-        "cpk_point": 1.3684157895755678,
+        "cp_point": 3.114,
+        "cpk_point": 1.368,
         "cp_interval": [
-            2.083734503514595, 3.9821885345379995
+            2.084, 3.982
         ],
         "cpk_interval": [
-            0.9767043263498091, 1.7328874880295368
-        ]
+            0.977, 1.733
+        ],
+        "error": null
     },
     "file168": {
         "data": [
@@ -2815,14 +3031,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 3.538739661861892,
-        "cpk_point": 2.1244433396550084,
+        "cp_point": 3.539,
+        "cpk_point": 2.124,
         "cp_interval": [
-            2.429730722114543, 4.551942060267982
+            2.43, 4.552
         ],
         "cpk_interval": [
-            1.3976935296961115, 2.786615977975378
-        ]
+            1.398, 2.787
+        ],
+        "error": null
     },
     "file169": {
         "data": [
@@ -2832,14 +3049,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 2.2064119123926087,
-        "cpk_point": 1.509340902836895,
+        "cp_point": 2.206,
+        "cpk_point": 1.509,
         "cp_interval": [
-            1.4896500741402128, 2.8256973815252615
+            1.49, 2.826
         ],
         "cpk_interval": [
-            1.0733346156575343, 1.9050215869043159
-        ]
+            1.073, 1.905
+        ],
+        "error": null
     },
     "file170": {
         "data": [
@@ -2849,14 +3067,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.1269166864569173,
-        "cpk_point": -0.0380795823804783,
+        "cp_point": 0.87,
+        "cpk_point": -0.038,
         "cp_interval": [
-            0.06780782253830667, 0.18746637114922043
+            0.465, 1.285
         ],
         "cpk_interval": [
-            -0.09302680807458695, 0.0203179044333422
-        ]
+            -0.093, 0.02
+        ],
+        "error": null
     },
     "file171": {
         "data": [
@@ -2866,14 +3085,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.9572755089680971,
-        "cpk_point": 0.8024921713190549,
+        "cp_point": 1.202,
+        "cpk_point": 1.138,
         "cp_interval": [
-            0.746447594722193, 1.1345990612836023
+            0.937, 1.425
         ],
         "cpk_interval": [
-            0.61133128633232, 0.9468880932531927
-        ]
+            0.722, 1.562
+        ],
+        "error": null
     },
     "file172": {
         "data": [
@@ -2883,14 +3103,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.2924810146802634,
-        "cpk_point": 0.7141623314640367,
+        "cp_point": 1.459,
+        "cpk_point": 1.506,
         "cp_interval": [
-            0.7874829892804623, 1.7802120459503845
+            0.889, 2.01
         ],
         "cpk_interval": [
-            0.5252132057282617, 0.8383764027003638
-        ]
+            0.828, 2.242
+        ],
+        "error": null
     },
     "file173": {
         "data": [
@@ -2900,14 +3121,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.6421486632344999,
-        "cpk_point": 0.6355399015700269,
+        "cp_point": 0.936,
+        "cpk_point": 0.636,
         "cp_interval": [
-            0.24840818639708673, 1.0689004039557988
+            0.362, 1.559
         ],
         "cpk_interval": [
-            0.21944031005387615, 0.7886929510674072
-        ]
+            0.219, 1.201
+        ],
+        "error": null
     },
     "file174": {
         "data": [
@@ -2917,14 +3139,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 2.0671220309284215,
-        "cpk_point": 0.8890558705791,
+        "cp_point": 2.176,
+        "cpk_point": 2.72,
         "cp_interval": [
-            1.4387617323495094, 2.637135527229744
+            1.514, 2.776
         ],
         "cpk_interval": [
-            0.7505804935743196, 1.0101309134941137
-        ]
+            1.7, 3.667
+        ],
+        "error": null
     },
     "file175": {
         "data": [
@@ -2934,14 +3157,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 2.4133681291516345,
-        "cpk_point": 0.93029792731156,
+        "cp_point": 2.54,
+        "cpk_point": 3.296,
         "cp_interval": [
-            1.6889335991192513, 3.057549347121259
+            1.778, 3.218
         ],
         "cpk_interval": [
-            0.7600056096574458, 1.0697642322282848
-        ]
+            2.08, 4.384
+        ],
+        "error": null
     },
     "file176": {
         "data": [
@@ -2951,14 +3175,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.2942384782445209,
-        "cpk_point": 0.7203976228042639,
+        "cp_point": 1.458,
+        "cpk_point": 1.508,
         "cp_interval": [
-            0.8292089696217029, 1.743841252406155
+            0.934, 1.965
         ],
         "cpk_interval": [
-            0.5494337362604454, 0.8360076673437143
-        ]
+            0.88, 2.186
+        ],
+        "error": null
     },
     "file177": {
         "data": [
@@ -2968,14 +3193,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 2.051189929141754,
-        "cpk_point": 0.715219850471065,
+        "cp_point": 2.302,
+        "cpk_point": 2.598,
         "cp_interval": [
-            1.315966026455806, 2.747730405289616
+            1.477, 3.084
         ],
         "cpk_interval": [
-            0.5344685579857483, 0.8401508768344161
-        ]
+            1.522, 3.704
+        ],
+        "error": null
     },
     "file178": {
         "data": [
@@ -2984,7 +3210,16 @@
         "upper_extreme": null,
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
-        "lower_specification": null
+        "lower_specification": null,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More unique values are required to calculate capability indexes."
     },
     "file179": {
         "data": [
@@ -2994,14 +3229,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 1.859764430174799,
-        "cpk_point": 0.6858949777759531,
+        "cp_point": 1.86,
+        "cpk_point": 0.686,
         "cp_interval": [
-            1.284935254377389, 2.3500449197154687
+            1.285, 2.35
         ],
         "cpk_interval": [
-            0.4287370587096762, 0.8905983891296503
-        ]
+            0.429, 0.891
+        ],
+        "error": null
     },
     "file180": {
         "data": [
@@ -3011,14 +3247,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 1.638018412470558,
-        "cpk_point": -0.5025213828253821,
+        "cp_point": 1.638,
+        "cpk_point": -0.503,
         "cp_interval": [
-            1.0961221379063768, 2.082086218190444
+            1.096, 2.082
         ],
         "cpk_interval": [
-            -0.6713668888638696, -0.27977032169838173
-        ]
+            -0.671, -0.28
+        ],
+        "error": null
     },
     "file181": {
         "data": [
@@ -3028,14 +3265,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 1.4951604187974563,
-        "cpk_point": 0.2825224773986615,
+        "cp_point": 1.495,
+        "cpk_point": 0.283,
         "cp_interval": [
-            1.028090005107679, 1.8938117249221558
+            1.028, 1.894
         ],
         "cpk_interval": [
-            0.11707624201522704, 0.4115202513830381
-        ]
+            0.117, 0.412
+        ],
+        "error": null
     },
     "file182": {
         "data": [
@@ -3045,14 +3283,15 @@
         "lower_extreme": null,
         "upper_specification": 10.0,
         "lower_specification": 2.0,
-        "cp_point": 2.011079531476243,
-        "cpk_point": 0.0536282738023883,
+        "cp_point": 2.011,
+        "cpk_point": 0.054,
         "cp_interval": [
-            1.5106801032294521, 2.476066334632675
+            1.511, 2.476
         ],
         "cpk_interval": [
-            -0.0369042195266478, 0.1713132972676235
-        ]
+            -0.037, 0.171
+        ],
+        "error": null
     },
     "file183": {
         "data": [
@@ -3062,14 +3301,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 1.745230490554826,
-        "cpk_point": -0.505144572822716,
+        "cp_point": 1.745,
+        "cpk_point": -0.505,
         "cp_interval": [
-            1.2372378528972778, 2.1997592849092
+            1.237, 2.2
         ],
         "cpk_interval": [
-            -0.6645534380938057, -0.30453424985655764
-        ]
+            -0.665, -0.305
+        ],
+        "error": null
     },
     "file184": {
         "data": [
@@ -3079,14 +3319,15 @@
         "lower_extreme": null,
         "upper_specification": 17.0,
         "lower_specification": 9.0,
-        "cp_point": 0.21629573493172913,
-        "cpk_point": 0.19848713137687873,
+        "cp_point": 0.216,
+        "cpk_point": 0.198,
         "cp_interval": [
-            1.0490402107383789e-08, 0.6904796852793802
+            0.0, 0.69
         ],
         "cpk_interval": [
-            9.201831268274695e-09, 0.40467222563836613
-        ]
+            0.0, 0.405
+        ],
+        "error": null
     },
     "file185": {
         "data": [
@@ -3096,14 +3337,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 3.0,
-        "cp_point": 1.519055153144669,
-        "cpk_point": 0.46688713203548293,
+        "cp_point": 1.519,
+        "cpk_point": 0.467,
         "cp_interval": [
-            1.0452583780380111, 1.7847037851895
+            1.045, 1.785
         ],
         "cpk_interval": [
-            0.22136446726063208, 0.5978350460058883
-        ]
+            0.221, 0.598
+        ],
+        "error": null
     },
     "file186": {
         "data": [
@@ -3113,14 +3355,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 3.0,
-        "cp_point": 0.3134374105906569,
-        "cpk_point": 0.15978228834924443,
+        "cp_point": 0.313,
+        "cpk_point": 0.16,
         "cp_interval": [
-            0.00013172256095348155, 0.949989077780657
+            0.0, 0.95
         ],
         "cpk_interval": [
-            6.602284242009268e-05, 0.6803748644685018
-        ]
+            0.0, 0.68
+        ],
+        "error": null
     },
     "file187": {
         "data": [
@@ -3130,14 +3373,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": 2.0,
-        "cp_point": 2.3148786769893865,
-        "cpk_point": 2.1403420427471933,
+        "cp_point": 2.315,
+        "cpk_point": 2.14,
         "cp_interval": [
-            1.3858239632249125, 2.7212282326652044
+            1.386, 2.721
         ],
         "cpk_interval": [
-            1.1204314353991582, 2.5891524439482674
-        ]
+            1.12, 2.589
+        ],
+        "error": null
     },
     "file188": {
         "data": [
@@ -3147,14 +3391,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": 2.0,
-        "cp_point": 2.2839041515867073,
-        "cpk_point": 1.802866308679365,
+        "cp_point": 2.284,
+        "cpk_point": 1.803,
         "cp_interval": [
-            1.7096374893648403, 2.662263939374795
+            1.71, 2.662
         ],
         "cpk_interval": [
-            1.1501353734311153, 2.41667241420029
-        ]
+            1.15, 2.417
+        ],
+        "error": null
     },
     "file189": {
         "data": [
@@ -3164,14 +3409,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 3.412205707484291,
-        "cpk_point": 0.8834375307452659,
+        "cp_point": 3.561,
+        "cpk_point": 5.379,
         "cp_interval": [
-            2.5770678005866396, 4.106666708025816
+            2.689, 4.285
         ],
         "cpk_interval": [
-            0.7426217883669004, 1.0139590070136104
-        ]
+            3.266, 7.205
+        ],
+        "error": null
     },
     "file190": {
         "data": [
@@ -3181,14 +3427,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 3.073000135889398,
-        "cpk_point": 0.8560997916668796,
+        "cp_point": 3.224,
+        "cpk_point": 4.327,
         "cp_interval": [
-            2.2196315328634855, 3.8424192041818945
+            2.329, 4.031
         ],
         "cpk_interval": [
-            0.7046036359529858, 0.9778499035099663
-        ]
+            2.856, 5.622
+        ],
+        "error": null
     },
     "file191": {
         "data": [
@@ -3198,14 +3445,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 1.9152100773361513,
-        "cpk_point": 0.909530766835849,
+        "cp_point": 2.006,
+        "cpk_point": 2.746,
         "cp_interval": [
-            0.18601497734008968, 2.2453535989663096
+            0.195, 2.352
         ],
         "cpk_interval": [
-            0.14955182078312398, 1.0308023651113667
-        ]
+            0.15, 3.636
+        ],
+        "error": null
     },
     "file192": {
         "data": [
@@ -3215,14 +3463,15 @@
         "lower_extreme": null,
         "upper_specification": 65.49,
         "lower_specification": 65.22,
-        "cp_point": 3.3902965924023483,
-        "cpk_point": 2.7289192993650255,
+        "cp_point": 3.39,
+        "cpk_point": 2.729,
         "cp_interval": [
-            2.3840774010968415, 4.299760963238248
+            2.384, 4.3
         ],
         "cpk_interval": [
-            1.8323569003907376, 3.52665106587182
-        ]
+            1.832, 3.527
+        ],
+        "error": null
     },
     "file193": {
         "data": [
@@ -3232,14 +3481,15 @@
         "lower_extreme": null,
         "upper_specification": 78.2,
         "lower_specification": 78.05,
-        "cp_point": 1.4185660632424713,
-        "cpk_point": 1.417051334238759,
+        "cp_point": 1.419,
+        "cpk_point": 1.417,
         "cp_interval": [
-            1.0053796979478966, 1.8003780231097353
+            1.005, 1.8
         ],
         "cpk_interval": [
-            0.9506552044618918, 1.7411670894726754
-        ]
+            0.951, 1.741
+        ],
+        "error": null
     },
     "file194": {
         "data": [
@@ -3249,14 +3499,15 @@
         "lower_extreme": null,
         "upper_specification": 77.046,
         "lower_specification": 76.985,
-        "cp_point": 0.25268638917893194,
-        "cpk_point": 0.1754453114495716,
+        "cp_point": 0.253,
+        "cpk_point": 0.175,
         "cp_interval": [
-            0.12835239357184536, 0.39435716646998237
+            0.128, 0.394
         ],
         "cpk_interval": [
-            0.07250090410662473, 0.33646819879801304
-        ]
+            0.073, 0.336
+        ],
+        "error": null
     },
     "file195": {
         "data": [
@@ -3266,14 +3517,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": -5.0,
-        "cp_point": 1.7245521584266958,
-        "cpk_point": 0.3806328095208074,
+        "cp_point": 1.725,
+        "cpk_point": 0.381,
         "cp_interval": [
-            1.2325594065169108, 2.1316152678552722
+            1.233, 2.132
         ],
         "cpk_interval": [
-            0.25396333830232476, 0.539652973313878
-        ]
+            0.254, 0.54
+        ],
+        "error": null
     },
     "file196": {
         "data": [
@@ -3283,14 +3535,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": -5.0,
-        "cp_point": 0.616817716111166,
-        "cpk_point": 0.2510094132481777,
+        "cp_point": 0.617,
+        "cpk_point": 0.251,
         "cp_interval": [
-            0.0001191005714316183, 1.1539192616505374
+            0.0, 1.154
         ],
         "cpk_interval": [
-            4.363022254867981e-05, 0.6649299890883282
-        ]
+            0.0, 0.665
+        ],
+        "error": null
     },
     "file197": {
         "data": [
@@ -3300,14 +3553,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 2.8689320605252275,
-        "cpk_point": 2.841899734688986,
+        "cp_point": 2.869,
+        "cpk_point": 2.842,
         "cp_interval": [
-            2.191689900547883, 3.370122671844236
+            2.192, 3.37
         ],
         "cpk_interval": [
-            1.7876489411382515, 3.1856779269170916
-        ]
+            1.788, 3.186
+        ],
+        "error": null
     },
     "file198": {
         "data": [
@@ -3317,14 +3571,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 1.5213648552125343,
-        "cpk_point": 1.2294926345301869,
+        "cp_point": 1.521,
+        "cpk_point": 1.229,
         "cp_interval": [
-            0.9905368233694852, 1.9765293842413942
+            0.991, 1.977
         ],
         "cpk_interval": [
-            0.7507307170950941, 1.6213712708854244
-        ]
+            0.751, 1.621
+        ],
+        "error": null
     },
     "file199": {
         "data": [
@@ -3334,14 +3589,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.19038898986763444,
-        "cpk_point": -0.001598689944311192,
+        "cp_point": 1.23,
+        "cpk_point": -0.002,
         "cp_interval": [
-            0.12724578084195398, 0.2517770326220452
+            0.822, 1.627
         ],
         "cpk_interval": [
-            -0.060979642509080334, 0.06955897332535779
-        ]
+            -0.061, 0.07
+        ],
+        "error": null
     },
     "file200": {
         "data": [
@@ -3351,14 +3607,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.0623207361882146,
-        "cpk_point": 0.038677955637689866,
+        "cp_point": 0.129,
+        "cpk_point": 0.039,
         "cp_interval": [
-            0.0035536116736145313, 0.20067671888269875
+            0.007, 0.414
         ],
         "cpk_interval": [
-            0.002126837456199445, 0.14661468846127618
-        ]
+            0.002, 0.147
+        ],
+        "error": null
     },
     "file201": {
         "data": [
@@ -3368,14 +3625,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.280819655109243,
-        "cpk_point": 0.7263924662806832,
+        "cp_point": 1.442,
+        "cpk_point": 1.462,
         "cp_interval": [
-            0.7774193353293791, 1.7796728138459512
+            0.875, 2.004
         ],
         "cpk_interval": [
-            0.5532076577178544, 0.8429396212753753
-        ]
+            0.809, 2.192
+        ],
+        "error": null
     },
     "file202": {
         "data": [
@@ -3385,14 +3643,15 @@
         "lower_extreme": null,
         "upper_specification": 46.26,
         "lower_specification": 46.05,
-        "cp_point": 7.190031379571582,
-        "cpk_point": 5.501996056467403,
+        "cp_point": 7.19,
+        "cpk_point": 5.502,
         "cp_interval": [
-            3.5316963472228435, 10.400959786507377
+            3.532, 10.401
         ],
         "cpk_interval": [
-            2.5234340529674917, 8.168024990830851
-        ]
+            2.523, 8.168
+        ],
+        "error": null
     },
     "file203": {
         "data": [
@@ -3402,14 +3661,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 10.0,
         "lower_specification": null,
-        "cp_point": 2.9015595137726864,
-        "cpk_point": 0.6614694098957742,
+        "cp_point": 4.002,
+        "cpk_point": 5.777,
         "cp_interval": [
-            1.4948085896626444, 3.689141866204675
+            2.062, 5.088
         ],
         "cpk_interval": [
-            0.20161611098257692, 0.8925162621146362
-        ]
+            2.526, 9.374
+        ],
+        "error": null
     },
     "file204": {
         "data": [
@@ -3419,14 +3679,15 @@
         "lower_extreme": null,
         "upper_specification": 48.0,
         "lower_specification": 47.9,
-        "cp_point": 0.9366647168880688,
-        "cpk_point": -0.9818647472619187,
+        "cp_point": 0.937,
+        "cpk_point": -0.982,
         "cp_interval": [
-            0.4101257759285077, 1.2074313370668146
+            0.41, 1.207
         ],
         "cpk_interval": [
-            -1.8208895330003412, -0.11362011250081337
-        ]
+            -1.821, -0.114
+        ],
+        "error": null
     },
     "file205": {
         "data": [
@@ -3436,14 +3697,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 10.0,
         "lower_specification": null,
-        "cp_point": 2.756883464592537,
-        "cpk_point": 0.6710344066194642,
+        "cp_point": 3.938,
+        "cpk_point": 4.871,
         "cp_interval": [
-            1.4430518058774984, 3.8880547360789994
+            2.062, 5.554
         ],
         "cpk_interval": [
-            0.2630119568444926, 1.0301664585139354
-        ]
+            2.552, 6.691
+        ],
+        "error": null
     },
     "file206": {
         "data": [
@@ -3453,14 +3715,15 @@
         "lower_extreme": null,
         "upper_specification": 49.948,
         "lower_specification": 49.9,
-        "cp_point": 2.842702547738558,
-        "cpk_point": 1.494032602380401,
+        "cp_point": 2.843,
+        "cpk_point": 1.494,
         "cp_interval": [
-            1.4098131991486387, 3.9935761709722315
+            1.41, 3.994
         ],
         "cpk_interval": [
-            0.7488956668786592, 2.2072367563652535
-        ]
+            0.749, 2.207
+        ],
+        "error": null
     },
     "file207": {
         "data": [
@@ -3470,14 +3733,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.4157328101483941,
-        "cpk_point": 0.6272572334879566,
+        "cp_point": 2.517,
+        "cpk_point": 1.745,
         "cp_interval": [
-            0.2752443374311944, 2.393008889832352
+            0.489, 4.254
         ],
         "cpk_interval": [
-            0.20133510218460465, 0.9057532013631202
-        ]
+            0.265, 3.328
+        ],
+        "error": null
     },
     "file208": {
         "data": [
@@ -3487,14 +3751,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.1982386648029373,
-        "cpk_point": 0.5320965385639539,
+        "cp_point": 1.87,
+        "cpk_point": 1.405,
         "cp_interval": [
-            0.08099493829694049, 2.2391503158230823
+            0.126, 3.495
         ],
         "cpk_interval": [
-            0.05463396179456521, 0.7705055711196058
-        ]
+            0.075, 3.08
+        ],
+        "error": null
     },
     "file209": {
         "data": [
@@ -3504,14 +3769,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 30.0,
         "lower_specification": null,
-        "cp_point": 0.017815029412567508,
-        "cpk_point": -1.1569407968315901,
+        "cp_point": 1.603,
+        "cpk_point": -1.157,
         "cp_interval": [
-            0.009552183611377257, 0.02219117659754329
+            0.86, 1.997
         ],
         "cpk_interval": [
-            -2.254294086107111, -0.14472699489028926
-        ]
+            -2.254, -0.145
+        ],
+        "error": null
     },
     "file210": {
         "data": [
@@ -3521,14 +3787,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 30.0,
         "lower_specification": null,
-        "cp_point": 0.053619991593741256,
-        "cpk_point": -0.031041774898787962,
+        "cp_point": 1.287,
+        "cpk_point": -0.031,
         "cp_interval": [
-            0.0018080069959669587, 0.11649242819425085
+            0.043, 2.796
         ],
         "cpk_interval": [
-            -0.177164654279944, 0.08757169320093044
-        ]
+            -0.177, 0.088
+        ],
+        "error": null
     },
     "file211": {
         "data": [
@@ -3538,14 +3805,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 50.0,
         "lower_specification": null,
-        "cp_point": 1.5302961568643507,
-        "cpk_point": 0.6960889790754585,
+        "cp_point": 3.327,
+        "cpk_point": 3.489,
         "cp_interval": [
-            0.688874228183067, 1.9532465117884485
+            1.498, 4.246
         ],
         "cpk_interval": [
-            0.21279224487233525, 0.9574466048496668
-        ]
+            1.55, 5.274
+        ],
+        "error": null
     },
     "file212": {
         "data": [
@@ -3555,14 +3823,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 1.8477760036993447,
-        "cpk_point": 0.8262721468805637,
+        "cp_point": 1.848,
+        "cpk_point": 0.826,
         "cp_interval": [
-            1.4849019202760554, 2.18267022109078
+            1.485, 2.183
         ],
         "cpk_interval": [
-            0.6429789373518779, 1.0266786288258187
-        ]
+            0.643, 1.027
+        ],
+        "error": null
     },
     "file213": {
         "data": [
@@ -3572,14 +3841,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.0957573488413535,
-        "cpk_point": 1.9340320065769336,
+        "cp_point": 2.096,
+        "cpk_point": 1.934,
         "cp_interval": [
-            1.620517637912005, 2.505759651847146
+            1.621, 2.506
         ],
         "cpk_interval": [
-            1.4262360105957936, 2.3543930695815454
-        ]
+            1.426, 2.354
+        ],
+        "error": null
     },
     "file214": {
         "data": [
@@ -3589,14 +3859,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 2.444490448266333,
-        "cpk_point": 2.237425389308275,
+        "cp_point": 2.444,
+        "cpk_point": 2.237,
         "cp_interval": [
-            1.9440948164810548, 2.9017676453402217
+            1.944, 2.902
         ],
         "cpk_interval": [
-            1.7331850943024427, 2.706862329191729
-        ]
+            1.733, 2.707
+        ],
+        "error": null
     },
     "file215": {
         "data": [
@@ -3606,14 +3877,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 4.079135913258863,
-        "cpk_point": 2.2745828344454564,
+        "cp_point": 4.079,
+        "cpk_point": 2.275,
         "cp_interval": [
-            3.2721983282275278, 4.825986854279112
+            3.272, 4.826
         ],
         "cpk_interval": [
-            1.7850827572700163, 2.7148574935763037
-        ]
+            1.785, 2.715
+        ],
+        "error": null
     },
     "file216": {
         "data": [
@@ -3623,14 +3895,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.948332144429473,
-        "cpk_point": 0.8815651100531626,
+        "cp_point": 1.181,
+        "cpk_point": 1.038,
         "cp_interval": [
-            0.8008303528930094, 1.0609110165375388
+            0.997, 1.321
         ],
         "cpk_interval": [
-            0.7115205008020005, 0.9949480653869642
-        ]
+            0.82, 1.266
+        ],
+        "error": null
     },
     "file217": {
         "data": [
@@ -3640,14 +3913,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.543126951931722,
-        "cpk_point": 0.48821622195766545,
+        "cp_point": 1.103,
+        "cpk_point": 0.488,
         "cp_interval": [
-            0.3869357474456593, 0.6962773404620063
+            0.786, 1.414
         ],
         "cpk_interval": [
-            0.3206246602873751, 0.6917564857852375
-        ]
+            0.321, 0.692
+        ],
+        "error": null
     },
     "file218": {
         "data": [
@@ -3657,14 +3931,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.7704363881939142,
-        "cpk_point": 0.7542185498441576,
+        "cp_point": 1.985,
+        "cpk_point": 2.693,
         "cp_interval": [
-            1.466184759779201, 1.9894621275805304
+            1.644, 2.23
         ],
         "cpk_interval": [
-            0.6472977906941493, 0.8807743836046436
-        ]
+            2.046, 3.279
+        ],
+        "error": null
     },
     "file219": {
         "data": [
@@ -3674,14 +3949,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.775857729744224,
-        "cpk_point": 0.746609575732788,
+        "cp_point": 1.99,
+        "cpk_point": 2.666,
         "cp_interval": [
-            1.461740871637754, 1.9939599736289662
+            1.638, 2.235
         ],
         "cpk_interval": [
-            0.6351224264295559, 0.8742784699107959
-        ]
+            2.025, 3.232
+        ],
+        "error": null
     },
     "file220": {
         "data": [
@@ -3691,14 +3967,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.1905132542541332,
-        "cpk_point": 0.9054465154664572,
+        "cp_point": 1.253,
+        "cpk_point": 1.328,
         "cp_interval": [
-            0.9501002098602113, 1.4221376552769565
+            1.0, 1.497
         ],
         "cpk_interval": [
-            0.8377320282435449, 0.970090363412112
-        ]
+            0.988, 1.684
+        ],
+        "error": null
     },
     "file221": {
         "data": [
@@ -3708,14 +3985,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.6499017385781607,
-        "cpk_point": 0.7639188905398975,
+        "cp_point": 1.845,
+        "cpk_point": 2.057,
         "cp_interval": [
-            1.1857225339731503, 1.9371904112232008
+            1.326, 2.167
         ],
         "cpk_interval": [
-            0.6260050202662034, 0.8704512155495263
-        ]
+            1.346, 2.507
+        ],
+        "error": null
     },
     "file222": {
         "data": [
@@ -3725,14 +4003,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 1.6223437070778943,
-        "cpk_point": 0.34098873186692685,
+        "cp_point": 1.622,
+        "cpk_point": 0.341,
         "cp_interval": [
-            1.1770551291225555, 2.003588101968839
+            1.177, 2.004
         ],
         "cpk_interval": [
-            0.18955209678937507, 0.4659660389772446
-        ]
+            0.19, 0.466
+        ],
+        "error": null
     },
     "file223": {
         "data": [
@@ -3742,14 +4021,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 1.8160377418471396,
-        "cpk_point": -0.4440560512306097,
+        "cp_point": 1.816,
+        "cpk_point": -0.444,
         "cp_interval": [
-            1.3451517218094213, 2.245289028148596
+            1.345, 2.245
         ],
         "cpk_interval": [
-            -0.5648215130420653, -0.29119673044587796
-        ]
+            -0.565, -0.291
+        ],
+        "error": null
     },
     "file224": {
         "data": [
@@ -3759,14 +4039,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 1.7780564048743868,
-        "cpk_point": 0.13055949866548844,
+        "cp_point": 1.778,
+        "cpk_point": 0.131,
         "cp_interval": [
-            1.2466911148638837, 2.2137767851922447
+            1.247, 2.214
         ],
         "cpk_interval": [
-            0.022738035488419316, 0.2725479056534099
-        ]
+            0.023, 0.273
+        ],
+        "error": null
     },
     "file225": {
         "data": [
@@ -3776,14 +4057,15 @@
         "lower_extreme": null,
         "upper_specification": 12.0,
         "lower_specification": 4.0,
-        "cp_point": 2.1272561643204915,
-        "cpk_point": 1.6658764517449955,
+        "cp_point": 2.127,
+        "cpk_point": 1.666,
         "cp_interval": [
-            1.7076180139328405, 2.4989620719455408
+            1.708, 2.499
         ],
         "cpk_interval": [
-            1.2952500000849776, 1.9813261342895987
-        ]
+            1.295, 1.981
+        ],
+        "error": null
     },
     "file226": {
         "data": [
@@ -3793,14 +4075,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.055889080191481,
-        "cpk_point": 0.14264063018642353,
+        "cp_point": 2.056,
+        "cpk_point": 0.143,
         "cp_interval": [
-            1.5100757931358382, 2.524212751579538
+            1.51, 2.524
         ],
         "cpk_interval": [
-            0.032018098213138745, 0.23821902235725834
-        ]
+            0.032, 0.238
+        ],
+        "error": null
     },
     "file227": {
         "data": [
@@ -3810,14 +4093,15 @@
         "lower_extreme": null,
         "upper_specification": 12.0,
         "lower_specification": 4.0,
-        "cp_point": 2.1589045988210867,
-        "cpk_point": 1.4503118671263273,
+        "cp_point": 2.159,
+        "cpk_point": 1.45,
         "cp_interval": [
-            1.737562616076993, 2.552712621716197
+            1.738, 2.553
         ],
         "cpk_interval": [
-            1.1580417927646731, 1.7316334909098048
-        ]
+            1.158, 1.732
+        ],
+        "error": null
     },
     "file228": {
         "data": [
@@ -3827,14 +4111,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 3.0,
-        "cp_point": 1.9286629403462077,
-        "cpk_point": 0.974498698023664,
+        "cp_point": 1.929,
+        "cpk_point": 0.974,
         "cp_interval": [
-            1.5467932791491097, 2.2756346904535567
+            1.547, 2.276
         ],
         "cpk_interval": [
-            0.7844016769908044, 1.1772206226406356
-        ]
+            0.784, 1.177
+        ],
+        "error": null
     },
     "file229": {
         "data": [
@@ -3844,14 +4129,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 1.6471404909729437,
-        "cpk_point": 0.806709926734298,
+        "cp_point": 1.647,
+        "cpk_point": 0.807,
         "cp_interval": [
-            1.2693737761761565, 1.9786858946732442
+            1.269, 1.979
         ],
         "cpk_interval": [
-            0.6463176901480684, 0.927063510254407
-        ]
+            0.646, 0.927
+        ],
+        "error": null
     },
     "file230": {
         "data": [
@@ -3861,14 +4147,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 1.4257150544190262,
-        "cpk_point": 0.3913618842332294,
+        "cp_point": 1.426,
+        "cpk_point": 0.391,
         "cp_interval": [
-            1.1417243654600544, 1.6893540685047534
+            1.142, 1.689
         ],
         "cpk_interval": [
-            0.28831631914638406, 0.5220854203701557
-        ]
+            0.288, 0.522
+        ],
+        "error": null
     },
     "file231": {
         "data": [
@@ -3878,14 +4165,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 3.0,
-        "cp_point": 1.588030679759056,
-        "cpk_point": 1.1812852083674585,
+        "cp_point": 1.588,
+        "cpk_point": 1.181,
         "cp_interval": [
-            1.0722217062517454, 1.8056323216676533
+            1.072, 1.806
         ],
         "cpk_interval": [
-            0.6865048901435287, 1.3878630355786796
-        ]
+            0.687, 1.388
+        ],
+        "error": null
     },
     "file232": {
         "data": [
@@ -3895,14 +4183,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 2.154727337675282,
-        "cpk_point": 1.8883977407728407,
+        "cp_point": 2.155,
+        "cpk_point": 1.888,
         "cp_interval": [
-            1.689656074761989, 2.569468260657539
+            1.69, 2.569
         ],
         "cpk_interval": [
-            1.4279571738122578, 2.3383467853766247
-        ]
+            1.428, 2.338
+        ],
+        "error": null
     },
     "file233": {
         "data": [
@@ -3912,14 +4201,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": 2.0,
-        "cp_point": 1.0880557214912583,
-        "cpk_point": 0.8797216588112193,
+        "cp_point": 1.088,
+        "cpk_point": 0.88,
         "cp_interval": [
-            0.8711137242111665, 1.2818319727625958
+            0.871, 1.282
         ],
         "cpk_interval": [
-            0.7074704603106933, 1.0631112249626307
-        ]
+            0.707, 1.063
+        ],
+        "error": null
     },
     "file234": {
         "data": [
@@ -3929,14 +4219,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 1.751897272694887,
-        "cpk_point": -0.13649439589554738,
+        "cp_point": 1.752,
+        "cpk_point": -0.136,
         "cp_interval": [
-            1.406073252013616, 2.067348433095106
+            1.406, 2.067
         ],
         "cpk_interval": [
-            -0.21857163338428465, -0.04682082595186621
-        ]
+            -0.219, -0.047
+        ],
+        "error": null
     },
     "file235": {
         "data": [
@@ -3946,14 +4237,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": 2.0,
-        "cp_point": 1.6874910006382484,
-        "cpk_point": 1.3172673816864808,
+        "cp_point": 1.687,
+        "cpk_point": 1.317,
         "cp_interval": [
-            1.3478938667235387, 2.0028621715713646
+            1.348, 2.003
         ],
         "cpk_interval": [
-            1.0610655499430743, 1.5299475850209947
-        ]
+            1.061, 1.53
+        ],
+        "error": null
     },
     "file236": {
         "data": [
@@ -3963,14 +4255,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.530159080824236,
-        "cpk_point": 0.9202053157854388,
+        "cp_point": 1.614,
+        "cpk_point": 1.862,
         "cp_interval": [
-            1.2320645924379123, 1.8093692607531946
+            1.3, 1.909
         ],
         "cpk_interval": [
-            0.831351596038148, 0.9959738636544154
-        ]
+            1.405, 2.312
+        ],
+        "error": null
     },
     "file237": {
         "data": [
@@ -3980,14 +4273,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 1.688068365837724,
-        "cpk_point": -0.6444246235655193,
+        "cp_point": 1.688,
+        "cpk_point": -0.644,
         "cp_interval": [
-            1.230729587801815, 2.018920445520103
+            1.231, 2.019
         ],
         "cpk_interval": [
-            -1.2197535982461396, -0.20792575300868468
-        ]
+            -1.22, -0.208
+        ],
+        "error": null
     },
     "file238": {
         "data": [
@@ -3997,14 +4291,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.6045594672166006,
-        "cpk_point": 0.7369207535908496,
+        "cp_point": 1.78,
+        "cpk_point": 1.945,
         "cp_interval": [
-            1.2234968178463634, 1.9745097240680176
+            1.357, 2.19
         ],
         "cpk_interval": [
-            0.6262351224396667, 0.818837239492631
-        ]
+            1.398, 2.51
+        ],
+        "error": null
     },
     "file239": {
         "data": [
@@ -4014,14 +4309,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 1.2155211383449256,
-        "cpk_point": 0.2810490102943226,
+        "cp_point": 1.216,
+        "cpk_point": 0.281,
         "cp_interval": [
-            0.7921900536874207, 1.576386925711684
+            0.792, 1.576
         ],
         "cpk_interval": [
-            0.1070186714612071, 0.4238601642918804
-        ]
+            0.107, 0.424
+        ],
+        "error": null
     },
     "file240": {
         "data": [
@@ -4031,14 +4327,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 1.0060578122129653,
-        "cpk_point": 0.8665757237023568,
+        "cp_point": 1.107,
+        "cpk_point": 1.077,
         "cp_interval": [
-            0.8017791202730514, 1.1989996608426912
+            0.882, 1.319
         ],
         "cpk_interval": [
-            0.7766731138974998, 0.9425529340052998
-        ]
+            0.803, 1.372
+        ],
+        "error": null
     },
     "file241": {
         "data": [
@@ -4048,14 +4345,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 1.564838691212429,
-        "cpk_point": 0.17318386158420238,
+        "cp_point": 1.565,
+        "cpk_point": 0.173,
         "cp_interval": [
-            1.0841182866677428, 1.9932225248080104
+            1.084, 1.993
         ],
         "cpk_interval": [
-            0.02497997671727332, 0.2942908536061489
-        ]
+            0.025, 0.294
+        ],
+        "error": null
     },
     "file242": {
         "data": [
@@ -4065,14 +4363,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 1.39602704245429,
-        "cpk_point": 0.14523664941122238,
+        "cp_point": 1.396,
+        "cpk_point": 0.145,
         "cp_interval": [
-            0.8178754743908598, 1.8418194012286908
+            0.818, 1.842
         ],
         "cpk_interval": [
-            0.009641496531991844, 0.3208306842714405
-        ]
+            0.01, 0.321
+        ],
+        "error": null
     },
     "file243": {
         "data": [
@@ -4082,14 +4381,15 @@
         "lower_extreme": null,
         "upper_specification": 60.65,
         "lower_specification": 60.4,
-        "cp_point": 3.1902995455904275,
-        "cpk_point": 2.476674749760171,
+        "cp_point": 3.19,
+        "cpk_point": 2.477,
         "cp_interval": [
-            2.543536836691185, 3.7826355389127952
+            2.544, 3.783
         ],
         "cpk_interval": [
-            1.918324835258408, 2.984677629640192
-        ]
+            1.918, 2.985
+        ],
+        "error": null
     },
     "file244": {
         "data": [
@@ -4099,14 +4399,15 @@
         "lower_extreme": null,
         "upper_specification": 73.7,
         "lower_specification": 73.55,
-        "cp_point": 1.406525839085709,
-        "cpk_point": 1.1770298645665873,
+        "cp_point": 1.407,
+        "cpk_point": 1.177,
         "cp_interval": [
-            1.0952343058570209, 1.570170369898556
+            1.095, 1.57
         ],
         "cpk_interval": [
-            0.8245491821013237, 1.3138185300998169
-        ]
+            0.825, 1.314
+        ],
+        "error": null
     },
     "file245": {
         "data": [
@@ -4116,14 +4417,15 @@
         "lower_extreme": null,
         "upper_specification": 72.821,
         "lower_specification": 72.765,
-        "cp_point": 0.912704158122922,
-        "cpk_point": 0.4614034869754961,
+        "cp_point": 0.913,
+        "cpk_point": 0.461,
         "cp_interval": [
-            0.7266325561534756, 1.0733262677646704
+            0.727, 1.073
         ],
         "cpk_interval": [
-            0.3324178711322332, 0.5692397815918043
-        ]
+            0.332, 0.569
+        ],
+        "error": null
     },
     "file246": {
         "data": [
@@ -4133,14 +4435,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 2.156184452730861,
-        "cpk_point": 1.8697351082802087,
+        "cp_point": 2.156,
+        "cpk_point": 1.87,
         "cp_interval": [
-            0.22166100969862748, 2.7270347890526043
+            0.222, 2.727
         ],
         "cpk_interval": [
-            0.17336868518807982, 2.43929457112978
-        ]
+            0.173, 2.439
+        ],
+        "error": null
     },
     "file247": {
         "data": [
@@ -4150,14 +4453,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 2.1260928261495917,
-        "cpk_point": 1.8745498297765533,
+        "cp_point": 2.126,
+        "cpk_point": 1.875,
         "cp_interval": [
-            0.9967238784308774, 3.106251962941463
+            0.997, 3.106
         ],
         "cpk_interval": [
-            0.7323242482097685, 2.893969760097371
-        ]
+            0.732, 2.894
+        ],
+        "error": null
     },
     "file248": {
         "data": [
@@ -4167,14 +4471,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.1779575385446911,
-        "cpk_point": -0.002167521965932379,
+        "cp_point": 1.246,
+        "cpk_point": -0.002,
         "cp_interval": [
-            0.09393048440639286, 0.25590474195522517
+            0.658, 1.791
         ],
         "cpk_interval": [
-            -0.08171338913617293, 0.09264519187209351
-        ]
+            -0.082, 0.093
+        ],
+        "error": null
     },
     "file249": {
         "data": [
@@ -4184,14 +4489,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.25517898263571587,
-        "cpk_point": 0.16273783045311982,
+        "cp_point": 0.547,
+        "cpk_point": 0.163,
         "cp_interval": [
-            0.09435191057808379, 0.4142456151832821
+            0.202, 0.888
         ],
         "cpk_interval": [
-            0.040558417360251446, 0.3341895806713477
-        ]
+            0.041, 0.334
+        ],
+        "error": null
     },
     "file250": {
         "data": [
@@ -4201,14 +4507,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.4074612692429787,
-        "cpk_point": 0.6698456179679362,
+        "cp_point": 1.609,
+        "cpk_point": 1.593,
         "cp_interval": [
-            0.3095537074378966, 2.550139276919748
+            0.354, 2.914
         ],
         "cpk_interval": [
-            0.25518120020861207, 0.8911785759703804
-        ]
+            0.298, 3.241
+        ],
+        "error": null
     },
     "file251": {
         "data": [
@@ -4218,14 +4525,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.9044490142719768,
-        "cpk_point": 0.7918514778418696,
+        "cp_point": 2.285,
+        "cpk_point": 3.633,
         "cp_interval": [
-            0.5337568510667666, 2.3716980533650216
+            0.641, 2.846
         ],
         "cpk_interval": [
-            0.42586269457409254, 0.9865551265400616
-        ]
+            0.516, 5.63
+        ],
+        "error": null
     },
     "file252": {
         "data": [
@@ -4235,14 +4543,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 2.6830346085683403,
-        "cpk_point": 0.8827522696855031,
+        "cp_point": 2.776,
+        "cpk_point": 4.128,
         "cp_interval": [
-            0.339379819055148, 3.484113560019457
+            0.351, 3.604
         ],
         "cpk_interval": [
-            0.2948326609943312, 0.9934256516614863
-        ]
+            0.303, 6.794
+        ],
+        "error": null
     },
     "file253": {
         "data": [
@@ -4251,7 +4560,16 @@
         "upper_extreme": null,
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
-        "lower_specification": null
+        "lower_specification": null,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More unique values are required to calculate capability indexes."
     },
     "file254": {
         "data": [
@@ -4261,14 +4579,15 @@
         "lower_extreme": null,
         "upper_specification": 10.0,
         "lower_specification": 2.0,
-        "cp_point": 2.381763147000448,
-        "cpk_point": 0.3542859891413331,
+        "cp_point": 2.382,
+        "cpk_point": 0.354,
         "cp_interval": [
-            1.5113117229631396, 3.1232984103382266
+            1.511, 3.123
         ],
         "cpk_interval": [
-            0.16188135108659457, 0.5489149645186456
-        ]
+            0.162, 0.549
+        ],
+        "error": null
     },
     "file255": {
         "data": [
@@ -4278,14 +4597,15 @@
         "lower_extreme": null,
         "upper_specification": 17.0,
         "lower_specification": 9.0,
-        "cp_point": 1.124086548575414,
-        "cpk_point": 1.099477647392364,
+        "cp_point": 1.124,
+        "cpk_point": 1.099,
         "cp_interval": [
-            0.40225145202646184, 1.6554151229525436
+            0.402, 1.655
         ],
         "cpk_interval": [
-            0.3598931424860976, 1.4418046983290904
-        ]
+            0.36, 1.442
+        ],
+        "error": null
     },
     "file256": {
         "data": [
@@ -4295,14 +4615,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 3.0,
-        "cp_point": 1.5920838683277525,
-        "cpk_point": 0.39174535213643497,
+        "cp_point": 1.592,
+        "cpk_point": 0.392,
         "cp_interval": [
-            1.0266134287401865, 1.9733170788810224
+            1.027, 1.973
         ],
         "cpk_interval": [
-            0.028791966401140106, 0.6304349635918007
-        ]
+            0.029, 0.63
+        ],
+        "error": null
     },
     "file257": {
         "data": [
@@ -4312,14 +4633,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 3.0,
-        "cp_point": 1.3556990593206237,
-        "cpk_point": 0.9703394437854906,
+        "cp_point": 1.356,
+        "cpk_point": 0.97,
         "cp_interval": [
-            0.7288970810988146, 1.8425394803903274
+            0.729, 1.843
         ],
         "cpk_interval": [
-            0.4194729559367755, 1.404054316407586
-        ]
+            0.419, 1.404
+        ],
+        "error": null
     },
     "file258": {
         "data": [
@@ -4329,14 +4651,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": 2.0,
-        "cp_point": 2.4441715676328255,
-        "cpk_point": 2.0404470514170936,
+        "cp_point": 2.444,
+        "cpk_point": 2.04,
         "cp_interval": [
-            1.179084462522045, 3.4689230880994955
+            1.179, 3.469
         ],
         "cpk_interval": [
-            1.0876786064436603, 2.8166681657194474
-        ]
+            1.088, 2.817
+        ],
+        "error": null
     },
     "file259": {
         "data": [
@@ -4345,7 +4668,16 @@
         "upper_extreme": null,
         "lower_extreme": null,
         "upper_specification": 8.0,
-        "lower_specification": 2.0
+        "lower_specification": 2.0,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More unique values are required to calculate capability indexes."
     },
     "file260": {
         "data": [
@@ -4355,14 +4687,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 1.9927123595443428,
-        "cpk_point": 0.793586274815796,
+        "cp_point": 1.993,
+        "cpk_point": 0.794,
         "cp_interval": [
-            0.9952282685948086, 2.868475546753569
+            0.995, 2.868
         ],
         "cpk_interval": [
-            0.3080830602215106, 1.2492723173279172
-        ]
+            0.308, 1.249
+        ],
+        "error": null
     },
     "file261": {
         "data": [
@@ -4372,14 +4705,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 2.6322341906001316,
-        "cpk_point": -1.0826229776094856,
+        "cp_point": 2.632,
+        "cpk_point": -1.083,
         "cp_interval": [
-            1.3106934508645705, 3.777061387810701
+            1.311, 3.777
         ],
         "cpk_interval": [
-            -1.5727209893405534, -0.5344325687577661
-        ]
+            -1.573, -0.534
+        ],
+        "error": null
     },
     "file262": {
         "data": [
@@ -4389,14 +4723,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 2.2457624449290163,
-        "cpk_point": 0.5098661463281787,
+        "cp_point": 2.246,
+        "cpk_point": 0.51,
         "cp_interval": [
-            1.1323793776818365, 3.225901364170874
+            1.132, 3.226
         ],
         "cpk_interval": [
-            0.16479135690246677, 0.8274910475527586
-        ]
+            0.165, 0.827
+        ],
+        "error": null
     },
     "file263": {
         "data": [
@@ -4406,14 +4741,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 3.1472992661128565,
-        "cpk_point": -1.8537153877565764,
+        "cp_point": 3.147,
+        "cpk_point": -1.854,
         "cp_interval": [
-            0.6377983903248927, 3.8363602537527766
+            0.638, 3.836
         ],
         "cpk_interval": [
-            -3.1001296890312817, -0.20596275823833993
-        ]
+            -3.1, -0.206
+        ],
+        "error": null
     },
     "file264": {
         "data": [
@@ -4423,14 +4759,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 4.773148277720575,
-        "cpk_point": 0.6748741307761715,
+        "cp_point": 4.967,
+        "cpk_point": 5.744,
         "cp_interval": [
-            0.6444893204909644, 8.926727882942417
+            0.671, 9.29
         ],
         "cpk_interval": [
-            0.33362484729942066, 0.9012953670304841
-        ]
+            0.65, 11.886
+        ],
+        "error": null
     },
     "file265": {
         "data": [
@@ -4440,14 +4777,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 4.1527095073650955,
-        "cpk_point": 0.6672752664420443,
+        "cp_point": 4.327,
+        "cpk_point": 5.053,
         "cp_interval": [
-            1.0169695853752732, 7.327291361812064
+            1.06, 7.634
         ],
         "cpk_interval": [
-            0.3605387575876448, 0.8849575985104804
-        ]
+            1.052, 9.738
+        ],
+        "error": null
     },
     "file266": {
         "data": [
@@ -4457,14 +4795,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 3.104753558424983,
-        "cpk_point": 0.7000067543414694,
+        "cp_point": 3.214,
+        "cpk_point": 3.771,
         "cp_interval": [
-            1.166296960957777, 5.027324566412372
+            1.207, 5.205
         ],
         "cpk_interval": [
-            0.4090306875909929, 0.8938077337534327
-        ]
+            1.226, 6.56
+        ],
+        "error": null
     },
     "file267": {
         "data": [
@@ -4474,14 +4813,15 @@
         "lower_extreme": null,
         "upper_specification": 65.49,
         "lower_specification": 65.22,
-        "cp_point": 4.342688420487979,
-        "cpk_point": 3.7742198548221952,
+        "cp_point": 4.343,
+        "cpk_point": 3.774,
         "cp_interval": [
-            2.249529294188193, 5.987563412658848
+            2.25, 5.988
         ],
         "cpk_interval": [
-            1.85618632747851, 5.452915136746609
-        ]
+            1.856, 5.453
+        ],
+        "error": null
     },
     "file268": {
         "data": [
@@ -4491,14 +4831,15 @@
         "lower_extreme": null,
         "upper_specification": 78.2,
         "lower_specification": 78.05,
-        "cp_point": 1.2068075971216585,
-        "cpk_point": 1.050329919506934,
+        "cp_point": 1.207,
+        "cpk_point": 1.05,
         "cp_interval": [
-            0.5099017908046419, 1.8290379256928666
+            0.51, 1.829
         ],
         "cpk_interval": [
-            0.3844464807125047, 1.7723895220961206
-        ]
+            0.384, 1.772
+        ],
+        "error": null
     },
     "file269": {
         "data": [
@@ -4508,14 +4849,15 @@
         "lower_extreme": null,
         "upper_specification": 77.046,
         "lower_specification": 76.985,
-        "cp_point": 0.4357917362475266,
-        "cpk_point": 0.3635810192157732,
+        "cp_point": 0.436,
+        "cpk_point": 0.364,
         "cp_interval": [
-            0.20634750223104323, 0.6467443843233854
+            0.206, 0.647
         ],
         "cpk_interval": [
-            0.07352016900818895, 0.5453874687034841
-        ]
+            0.074, 0.545
+        ],
+        "error": null
     },
     "file270": {
         "data": [
@@ -4525,14 +4867,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": -5.0,
-        "cp_point": 1.635735706380635,
-        "cpk_point": 0.5688538219316177,
+        "cp_point": 1.636,
+        "cpk_point": 0.569,
         "cp_interval": [
-            1.0205909654096461, 2.1811759014771197
+            1.021, 2.181
         ],
         "cpk_interval": [
-            0.3163866216934518, 0.8337257375104928
-        ]
+            0.316, 0.834
+        ],
+        "error": null
     },
     "file271": {
         "data": [
@@ -4542,14 +4885,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": -5.0,
-        "cp_point": 1.8661628110740778,
-        "cpk_point": 1.0877986611095645,
+        "cp_point": 1.866,
+        "cpk_point": 1.088,
         "cp_interval": [
-            1.1543962351286654, 2.4970380570173023
+            1.154, 2.497
         ],
         "cpk_interval": [
-            0.6386365315821795, 1.5267116962040743
-        ]
+            0.639, 1.527
+        ],
+        "error": null
     },
     "file272": {
         "data": [
@@ -4559,14 +4903,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.502045759532791,
-        "cpk_point": 1.039658755977498,
+        "cp_point": 2.502,
+        "cpk_point": 1.04,
         "cp_interval": [
-            0.8255945114489575, 3.9253521017621074
+            0.826, 3.925
         ],
         "cpk_interval": [
-            0.2654043239858405, 1.8055847707113424
-        ]
+            0.265, 1.806
+        ],
+        "error": null
     },
     "file273": {
         "data": [
@@ -4576,14 +4921,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 1.4802204390850253,
-        "cpk_point": 0.7165855860251278,
+        "cp_point": 1.48,
+        "cpk_point": 0.717,
         "cp_interval": [
-            0.25188705271782447, 2.4478336742686517
+            0.252, 2.448
         ],
         "cpk_interval": [
-            0.12693687898738265, 1.1659059966871876
-        ]
+            0.127, 1.166
+        ],
+        "error": null
     },
     "file274": {
         "data": [
@@ -4593,14 +4939,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 4.783034168621168,
-        "cpk_point": 0.9000667153170465,
+        "cp_point": 4.783,
+        "cpk_point": 0.9,
         "cp_interval": [
-            1.654500273149753, 7.405866745278105
+            1.655, 7.406
         ],
         "cpk_interval": [
-            0.25377980488625695, 1.451792936352879
-        ]
+            0.254, 1.452
+        ],
+        "error": null
     },
     "file275": {
         "data": [
@@ -4610,14 +4957,15 @@
         "lower_extreme": null,
         "upper_specification": 12.0,
         "lower_specification": 4.0,
-        "cp_point": 2.8073114759069155,
-        "cpk_point": 1.7436390545945144,
+        "cp_point": 2.807,
+        "cpk_point": 1.744,
         "cp_interval": [
-            1.5801845659755138, 3.8555980922732975
+            1.58, 3.856
         ],
         "cpk_interval": [
-            0.9267102257797688, 2.540972393278918
-        ]
+            0.927, 2.541
+        ],
+        "error": null
     },
     "file276": {
         "data": [
@@ -4627,14 +4975,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.874011311733181,
-        "cpk_point": 1.1223635884501935,
+        "cp_point": 2.874,
+        "cpk_point": 1.122,
         "cp_interval": [
-            0.004712805749972104, 4.127205248470944
+            0.005, 4.127
         ],
         "cpk_interval": [
-            0.004039877323225067, 1.708213653395394
-        ]
+            0.004, 1.708
+        ],
+        "error": null
     },
     "file277": {
         "data": [
@@ -4644,14 +4993,15 @@
         "lower_extreme": null,
         "upper_specification": 20.0,
         "lower_specification": 10.0,
-        "cp_point": 3.4915002763274674,
-        "cpk_point": 2.9817060228107604,
+        "cp_point": 3.492,
+        "cpk_point": 2.982,
         "cp_interval": [
-            1.948968149925394, 4.801120618050059
+            1.949, 4.801
         ],
         "cpk_interval": [
-            1.5687113539428919, 4.312641647955908
-        ]
+            1.569, 4.313
+        ],
+        "error": null
     },
     "file278": {
         "data": [
@@ -4661,14 +5011,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 2.8008368558727335,
-        "cpk_point": 1.7568628462451494,
+        "cp_point": 2.801,
+        "cpk_point": 1.757,
         "cp_interval": [
-            1.5756540925289668, 3.8477527718446685
+            1.576, 3.848
         ],
         "cpk_interval": [
-            0.9327988522394018, 2.55924793264907
-        ]
+            0.933, 2.559
+        ],
+        "error": null
     },
     "file279": {
         "data": [
@@ -4678,14 +5029,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": 1.0,
-        "cp_point": 1.6179068562357313,
-        "cpk_point": 1.1396552278802576,
+        "cp_point": 1.618,
+        "cpk_point": 1.14,
         "cp_interval": [
-            0.8370136346704601, 2.0709709276957673
+            0.837, 2.071
         ],
         "cpk_interval": [
-            0.4226068981358347, 1.639354972527909
-        ]
+            0.423, 1.639
+        ],
+        "error": null
     },
     "file280": {
         "data": [
@@ -4695,14 +5047,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 2.611196568260947,
-        "cpk_point": 1.6920799311400567,
+        "cp_point": 2.611,
+        "cpk_point": 1.692,
         "cp_interval": [
-            1.4602456263372863, 3.5995972478469604
+            1.46, 3.6
         ],
         "cpk_interval": [
-            0.8898288713874201, 2.489693011667849
-        ]
+            0.89, 2.49
+        ],
+        "error": null
     },
     "file281": {
         "data": [
@@ -4711,7 +5064,16 @@
         "upper_extreme": null,
         "lower_extreme": null,
         "upper_specification": 5.0,
-        "lower_specification": 1.0
+        "lower_specification": 1.0,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More unique values are required to calculate capability indexes."
     },
     "file282": {
         "data": [
@@ -4721,14 +5083,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 1.6742534762466905,
-        "cpk_point": 1.4874626096178856,
+        "cp_point": 1.674,
+        "cpk_point": 1.487,
         "cp_interval": [
-            0.7419588828561777, 2.3921651685769176
+            0.742, 2.392
         ],
         "cpk_interval": [
-            0.6279443315758702, 1.9898879454328988
-        ]
+            0.628, 1.99
+        ],
+        "error": null
     },
     "file283": {
         "data": [
@@ -4738,14 +5101,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 1.0,
-        "cp_point": 1.8956392402506819,
-        "cpk_point": 1.4236941061518913,
+        "cp_point": 1.896,
+        "cpk_point": 1.424,
         "cp_interval": [
-            1.0116470349475506, 2.678111433863002
+            1.012, 2.678
         ],
         "cpk_interval": [
-            0.7038516629987398, 2.1337223565813725
-        ]
+            0.704, 2.134
+        ],
+        "error": null
     },
     "file284": {
         "data": [
@@ -4755,14 +5119,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 2.228995885608337,
-        "cpk_point": 2.071231881782935,
+        "cp_point": 2.229,
+        "cpk_point": 2.071,
         "cp_interval": [
-            1.0687708162925529, 3.134394905012541
+            1.069, 3.134
         ],
         "cpk_interval": [
-            0.937511974537106, 2.743814780093562
-        ]
+            0.938, 2.744
+        ],
+        "error": null
     },
     "file285": {
         "data": [
@@ -4772,14 +5137,15 @@
         "lower_extreme": null,
         "upper_specification": 18.0,
         "lower_specification": 12.0,
-        "cp_point": 2.403227766110015,
-        "cpk_point": 2.2921134252607094,
+        "cp_point": 2.403,
+        "cpk_point": 2.292,
         "cp_interval": [
-            1.230628679615681, 3.0073594796197023
+            1.231, 3.007
         ],
         "cpk_interval": [
-            0.9485356023880955, 2.825751230078842
-        ]
+            0.949, 2.826
+        ],
+        "error": null
     },
     "file286": {
         "data": [
@@ -4789,14 +5155,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 3.071009127547185,
-        "cpk_point": 0.7727271114104514,
+        "cp_point": 3.276,
+        "cpk_point": 4.001,
         "cp_interval": [
-            1.4994731095541665, 4.523016660833523
+            1.599, 4.825
         ],
         "cpk_interval": [
-            0.4885361090190622, 0.9566956968760614
-        ]
+            1.694, 6.399
+        ],
+        "error": null
     },
     "file287": {
         "data": [
@@ -4806,14 +5173,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 3.784353056899151,
-        "cpk_point": 0.8162073276351052,
+        "cp_point": 3.957,
+        "cpk_point": 5.495,
         "cp_interval": [
-            2.0025585942593747, 4.846443514239148
+            2.094, 5.068
         ],
         "cpk_interval": [
-            0.3685609400616464, 0.9679063465743588
-        ]
+            2.5, 8.77
+        ],
+        "error": null
     },
     "file288": {
         "data": [
@@ -4823,14 +5191,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 1.526270879010798,
-        "cpk_point": 0.7801004798506735,
+        "cp_point": 1.679,
+        "cpk_point": 1.999,
         "cp_interval": [
-            0.9384140306837193, 2.066941257173824
+            1.032, 2.274
         ],
         "cpk_interval": [
-            0.5697072686809097, 0.9603594685688999
-        ]
+            1.042, 2.906
+        ],
+        "error": null
     },
     "file289": {
         "data": [
@@ -4840,14 +5209,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.236126325669442,
-        "cpk_point": 1.5314667496277248,
+        "cp_point": 2.236,
+        "cpk_point": 1.531,
         "cp_interval": [
-            0.5698855278380591, 2.7811923503533764
+            0.57, 2.781
         ],
         "cpk_interval": [
-            0.3801782168345231, 2.25464446377583
-        ]
+            0.38, 2.255
+        ],
+        "error": null
     },
     "file290": {
         "data": [
@@ -4857,14 +5227,15 @@
         "lower_extreme": null,
         "upper_specification": 42.2,
         "lower_specification": 41.95,
-        "cp_point": 3.8976646509561967,
-        "cpk_point": 2.4992632788467177,
+        "cp_point": 3.898,
+        "cpk_point": 2.499,
         "cp_interval": [
-            2.225338133655439, 5.306326044877886
+            2.225, 5.306
         ],
         "cpk_interval": [
-            1.356226120779561, 3.5738454113739735
-        ]
+            1.356, 3.574
+        ],
+        "error": null
     },
     "file291": {
         "data": [
@@ -4874,14 +5245,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 1.6111242602872713,
-        "cpk_point": 1.1023337428837938,
+        "cp_point": 1.611,
+        "cpk_point": 1.102,
         "cp_interval": [
-            0.5140978009048878, 2.4991279849821804
+            0.514, 2.499
         ],
         "cpk_interval": [
-            0.4643324243804725, 1.5422198040554265
-        ]
+            0.464, 1.542
+        ],
+        "error": null
     },
     "file292": {
         "data": [
@@ -4891,14 +5263,15 @@
         "lower_extreme": null,
         "upper_specification": 51.8,
         "lower_specification": 51.65,
-        "cp_point": 2.9616766240026826,
-        "cpk_point": 2.3722030662314944,
+        "cp_point": 2.962,
+        "cpk_point": 2.372,
         "cp_interval": [
-            1.5468542231446987, 3.71766853981475
+            1.547, 3.718
         ],
         "cpk_interval": [
-            1.2221289714972186, 3.2286767373518095
-        ]
+            1.222, 3.229
+        ],
+        "error": null
     },
     "file293": {
         "data": [
@@ -4908,14 +5281,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.993588063801315,
-        "cpk_point": 1.2605812383524029,
+        "cp_point": 2.994,
+        "cpk_point": 1.261,
         "cp_interval": [
-            1.2470396984607206, 4.4015855103323105
+            1.247, 4.402
         ],
         "cpk_interval": [
-            0.6159261252135262, 1.8035054168828069
-        ]
+            0.616, 1.804
+        ],
+        "error": null
     },
     "file294": {
         "data": [
@@ -4925,14 +5299,15 @@
         "lower_extreme": null,
         "upper_specification": 50.876,
         "lower_specification": 50.819,
-        "cp_point": 1.1253970331413083,
-        "cpk_point": 0.580789844881272,
+        "cp_point": 1.125,
+        "cpk_point": 0.581,
         "cp_interval": [
-            0.2976963233562095, 1.6570707377525198
+            0.298, 1.657
         ],
         "cpk_interval": [
-            0.2002881719943617, 0.8834967920634491
-        ]
+            0.2, 0.883
+        ],
+        "error": null
     },
     "file295": {
         "data": [
@@ -4942,14 +5317,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.0618681274249164,
-        "cpk_point": 0.6853011828618438,
+        "cp_point": 2.062,
+        "cpk_point": 0.685,
         "cp_interval": [
-            0.936558599727318, 2.992540462046391
+            0.937, 2.993
         ],
         "cpk_interval": [
-            0.2510892311657307, 1.0350697719711466
-        ]
+            0.251, 1.035
+        ],
+        "error": null
     },
     "file296": {
         "data": [
@@ -4959,14 +5335,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 3.4783719420454897,
-        "cpk_point": 1.517107322408696,
+        "cp_point": 3.478,
+        "cpk_point": 1.517,
         "cp_interval": [
-            2.004925584416962, 4.697737557166708
+            2.005, 4.698
         ],
         "cpk_interval": [
-            0.8640142547702507, 2.151373348503733
-        ]
+            0.864, 2.151
+        ],
+        "error": null
     },
     "file297": {
         "data": [
@@ -4976,14 +5353,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 4.44850134368662,
-        "cpk_point": 1.5595623392142834,
+        "cp_point": 4.449,
+        "cpk_point": 1.56,
         "cp_interval": [
-            2.4404282970197952, 6.064839752167756
+            2.44, 6.065
         ],
         "cpk_interval": [
-            0.9518403829242333, 2.135148177384418
-        ]
+            0.952, 2.135
+        ],
+        "error": null
     },
     "file298": {
         "data": [
@@ -4993,14 +5371,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 2.92860997485748,
-        "cpk_point": 1.8269479998314155,
+        "cp_point": 2.929,
+        "cpk_point": 1.827,
         "cp_interval": [
-            1.6516174741957617, 4.016771110220398
+            1.652, 4.017
         ],
         "cpk_interval": [
-            0.973929753965099, 2.642505582222688
-        ]
+            0.974, 2.643
+        ],
+        "error": null
     },
     "file299": {
         "data": [
@@ -5010,14 +5389,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 2.4652485297557027,
-        "cpk_point": 1.7299852311637693,
+        "cp_point": 2.465,
+        "cpk_point": 1.73,
         "cp_interval": [
-            1.3890085369285168, 3.351216300580403
+            1.389, 3.351
         ],
         "cpk_interval": [
-            1.0344858911482815, 2.385731444477196
-        ]
+            1.034, 2.386
+        ],
+        "error": null
     },
     "file300": {
         "data": [
@@ -5027,14 +5407,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.5670491910917392,
-        "cpk_point": 0.40640562284474935,
+        "cp_point": 1.276,
+        "cpk_point": 0.406,
         "cp_interval": [
-            0.33819018748111357, 0.7138836929630742
+            0.761, 1.606
         ],
         "cpk_interval": [
-            -0.02150944285378907, 0.6065459953180233
-        ]
+            -0.022, 0.67
+        ],
+        "error": null
     },
     "file301": {
         "data": [
@@ -5043,7 +5424,16 @@
         "upper_extreme": null,
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
-        "lower_specification": null
+        "lower_specification": null,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More unique values are required to calculate capability indexes."
     },
     "file302": {
         "data": [
@@ -5053,14 +5443,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.5629147748771521,
-        "cpk_point": 0.6873619532400318,
+        "cp_point": 1.776,
+        "cpk_point": 1.81,
         "cp_interval": [
-            0.5180547999131273, 2.5384711646658458
+            0.589, 2.885
         ],
         "cpk_interval": [
-            0.37983677699638646, 0.856548868535584
-        ]
+            0.521, 3.237
+        ],
+        "error": null
     },
     "file303": {
         "data": [
@@ -5070,14 +5461,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.8824428288801315,
-        "cpk_point": 0.6289864923242828,
+        "cp_point": 1.302,
+        "cpk_point": 0.949,
         "cp_interval": [
-            0.17880362082385767, 1.5571108606507085
+            0.264, 2.297
         ],
         "cpk_interval": [
-            0.16482711611573236, 0.8083112688776005
-        ]
+            0.165, 1.893
+        ],
+        "error": null
     },
     "file304": {
         "data": [
@@ -5087,14 +5479,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.5629147748771521,
-        "cpk_point": 0.6873619532400318,
+        "cp_point": 1.776,
+        "cpk_point": 1.81,
         "cp_interval": [
-            0.5180547999131273, 2.5384711646658458
+            0.589, 2.885
         ],
         "cpk_interval": [
-            0.37983677699638646, 0.856548868535584
-        ]
+            0.521, 3.237
+        ],
+        "error": null
     },
     "file305": {
         "data": [
@@ -5104,14 +5497,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.3953257758739583,
-        "cpk_point": 0.8532347752586901,
+        "cp_point": 1.431,
+        "cpk_point": 1.545,
         "cp_interval": [
-            0.6624638077071856, 2.0416906786139726
+            0.679, 2.094
         ],
         "cpk_interval": [
-            0.600999544499279, 0.9305990440160902
-        ]
+            0.646, 2.482
+        ],
+        "error": null
     },
     "file306": {
         "data": [
@@ -5121,14 +5515,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 25.0,
         "lower_specification": null,
-        "cp_point": 0.0008876966302377288,
-        "cpk_point": -0.021745232501618347,
+        "cp_point": 0.067,
+        "cpk_point": -0.022,
         "cp_interval": [
-            1.3761449239330274e-21, 0.002359572648038511
+            0.0, 0.177
         ],
         "cpk_interval": [
-            -0.06787114609486185, -3.3885176794161946e-20
-        ]
+            -0.068, -0.0
+        ],
+        "error": null
     },
     "file307": {
         "data": [
@@ -5138,14 +5533,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 25.0,
         "lower_specification": null,
-        "cp_point": 0.0003743271449305626,
-        "cpk_point": -0.02042649289437601,
+        "cp_point": 0.028,
+        "cpk_point": -0.02,
         "cp_interval": [
-            4.45359747644089e-07, 0.0016752507000675227
+            0.0, 0.126
         ],
         "cpk_interval": [
-            -0.09107432358243493, -3.5544599191392064e-05
-        ]
+            -0.091, -0.0
+        ],
+        "error": null
     },
     "file308": {
         "data": [
@@ -5155,14 +5551,15 @@
         "lower_extreme": null,
         "upper_specification": 45.335,
         "lower_specification": 45.315,
-        "cp_point": 0.24317457772888282,
-        "cpk_point": 0.14227901561840803,
+        "cp_point": 0.243,
+        "cpk_point": 0.142,
         "cp_interval": [
-            1.9893389640358382e-14, 0.33479815136073166
+            0.0, 0.335
         ],
         "cpk_interval": [
-            9.211261831970145e-18, 0.2406325142156694
-        ]
+            0.0, 0.241
+        ],
+        "error": null
     },
     "file309": {
         "data": [
@@ -5172,14 +5569,15 @@
         "lower_extreme": null,
         "upper_specification": 45.335,
         "lower_specification": 45.315,
-        "cp_point": 0.1645278492936789,
-        "cpk_point": 0.15175628459752855,
+        "cp_point": 0.165,
+        "cpk_point": 0.152,
         "cp_interval": [
-            3.754206185315683e-06, 0.34742180820160595
+            0.0, 0.347
         ],
         "cpk_interval": [
-            -0.000104597355569941, 0.3015652597022769
-        ]
+            -0.0, 0.302
+        ],
+        "error": null
     },
     "file310": {
         "data": [
@@ -5189,14 +5587,15 @@
         "lower_extreme": null,
         "upper_specification": 45.335,
         "lower_specification": 45.315,
-        "cp_point": 0.2516145764937264,
-        "cpk_point": 0.06441143924721095,
+        "cp_point": 0.252,
+        "cpk_point": 0.064,
         "cp_interval": [
-            3.1898799899377645e-07, 0.3393078510303459
+            0.0, 0.339
         ],
         "cpk_interval": [
-            -0.023484195601243492, 0.14134072790775187
-        ]
+            -0.023, 0.141
+        ],
+        "error": null
     },
     "file311": {
         "data": [
@@ -5206,14 +5605,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 50.0,
         "lower_specification": null,
-        "cp_point": 3.9762503597421697,
-        "cpk_point": 0.7770850574430906,
+        "cp_point": 4.829,
+        "cpk_point": 5.201,
         "cp_interval": [
-            1.669423711720766, 5.283009809926277
+            2.028, 6.417
         ],
         "cpk_interval": [
-            0.28234781495666306, 0.9844671169248171
-        ]
+            1.875, 10.339
+        ],
+        "error": null
     },
     "file312": {
         "data": [
@@ -5223,14 +5623,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 20.0,
         "lower_specification": null,
-        "cp_point": 1.7503659359973278,
-        "cpk_point": 0.7381499735557913,
+        "cp_point": 1.945,
+        "cpk_point": 1.945,
         "cp_interval": [
-            0.14855755783394858, 3.4373297611331757
+            0.165, 3.819
         ],
         "cpk_interval": [
-            0.1420337604444363, 0.9157725113777905
-        ]
+            0.142, 4.312
+        ],
+        "error": null
     },
     "file313": {
         "data": [
@@ -5240,14 +5641,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 20.0,
         "lower_specification": null,
-        "cp_point": 2.6027898415442596,
-        "cpk_point": 0.7981062899842489,
+        "cp_point": 2.892,
+        "cpk_point": 3.927,
         "cp_interval": [
-            1.6097113095409106, 3.49441160220738
+            1.789, 3.883
         ],
         "cpk_interval": [
-            0.4972952168895918, 1.0303870984621912
-        ]
+            2.156, 5.508
+        ],
+        "error": null
     },
     "file314": {
         "data": [
@@ -5257,14 +5659,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 2.8198606862422095,
-        "cpk_point": 0.5121653555951635,
+        "cp_point": 3.646,
+        "cpk_point": 3.835,
         "cp_interval": [
-            0.9495518849397159, 4.36137463968087
+            1.228, 5.639
         ],
         "cpk_interval": [
-            0.1981085137837289, 0.7110620218703396
-        ]
+            1.058, 6.465
+        ],
+        "error": null
     },
     "file315": {
         "data": [
@@ -5274,14 +5677,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 3.0123288757793474,
-        "cpk_point": 0.6183821411860942,
+        "cp_point": 3.661,
+        "cpk_point": 5.068,
         "cp_interval": [
-            1.8505214029038137, 4.0185974432131575
+            2.249, 4.883
         ],
         "cpk_interval": [
-            0.3024847333052734, 0.8371688585783371
-        ]
+            2.925, 6.947
+        ],
+        "error": null
     },
     "file316": {
         "data": [
@@ -5291,14 +5695,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 15.0,
         "lower_specification": null,
-        "cp_point": 0.65366230354258,
-        "cpk_point": 0.5599527313209672,
+        "cp_point": 1.171,
+        "cpk_point": 0.662,
         "cp_interval": [
-            1.8398108847836667e-21, 1.5830293620808666
+            0.0, 2.835
         ],
         "cpk_interval": [
-            1.7245464568416576e-21, 0.8070516641175384
-        ]
+            0.0, 1.909
+        ],
+        "error": null
     },
     "file317": {
         "data": [
@@ -5308,14 +5713,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 15.0,
         "lower_specification": null,
-        "cp_point": 0.6527563172082227,
-        "cpk_point": 0.6454215600877914,
+        "cp_point": 0.89,
+        "cpk_point": 0.645,
         "cp_interval": [
-            0.2575896042422612, 1.0156143971854525
+            0.351, 1.385
         ],
         "cpk_interval": [
-            0.22477393474660096, 0.827183207305397
-        ]
+            0.225, 1.13
+        ],
+        "error": null
     },
     "file318": {
         "data": [
@@ -5325,14 +5731,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.8650590966387568,
-        "cpk_point": 0.7008987936060279,
+        "cp_point": 2.295,
+        "cpk_point": 2.214,
         "cp_interval": [
-            0.35614500065703014, 3.1901463433800443
+            0.438, 3.926
         ],
         "cpk_interval": [
-            0.27390154331881905, 0.8934278367044519
-        ]
+            0.349, 4.23
+        ],
+        "error": null
     },
     "file319": {
         "data": [
@@ -5342,14 +5749,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 2.427900678739756,
-        "cpk_point": 0.5544899989853085,
+        "cp_point": 3.139,
+        "cpk_point": 2.952,
         "cp_interval": [
-            2.9243709986561762e-21, 3.4318809855543564
+            0.0, 4.437
         ],
         "cpk_interval": [
-            2.769720097634131e-21, 0.806910203213264
-        ]
+            0.0, 4.476
+        ],
+        "error": null
     },
     "file320": {
         "data": [
@@ -5359,14 +5767,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 20.0,
         "lower_specification": null,
-        "cp_point": 0.001973709773325894,
-        "cpk_point": -0.006039501920071582,
+        "cp_point": 0.02,
+        "cpk_point": -0.006,
         "cp_interval": [
-            3.132782053252428e-07, 0.015104135637076141
+            0.0, 0.151
         ],
         "cpk_interval": [
-            -0.04820577058973471, -9.279115223031674e-07
-        ]
+            -0.048, -0.0
+        ],
+        "error": null
     },
     "file321": {
         "data": [
@@ -5376,14 +5785,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 20.0,
         "lower_specification": null,
-        "cp_point": 0.0004665035240890303,
-        "cpk_point": -0.009884845820834933,
+        "cp_point": 0.037,
+        "cpk_point": -0.01,
         "cp_interval": [
-            1.7810432959111703e-19, 0.0026125309521200296
+            0.0, 0.209
         ],
         "cpk_interval": [
-            -0.07448713196634532, -2.5646073933961753e-18
-        ]
+            -0.074, -0.0
+        ],
+        "error": null
     },
     "file322": {
         "data": [
@@ -5393,14 +5803,15 @@
         "lower_extreme": null,
         "upper_specification": 45.03,
         "lower_specification": 45.01,
-        "cp_point": 0.13177907904339417,
-        "cpk_point": 0.05015062628821158,
+        "cp_point": 0.132,
+        "cpk_point": 0.05,
         "cp_interval": [
-            0.014753574020998571, 0.2666480545789717
+            0.015, 0.267
         ],
         "cpk_interval": [
-            -0.006424243220703237, 0.14031014541518663
-        ]
+            -0.006, 0.14
+        ],
+        "error": null
     },
     "file323": {
         "data": [
@@ -5410,14 +5821,15 @@
         "lower_extreme": null,
         "upper_specification": 45.03,
         "lower_specification": 45.01,
-        "cp_point": 0.10978514654692055,
-        "cpk_point": 0.06479343130383304,
+        "cp_point": 0.11,
+        "cpk_point": 0.065,
         "cp_interval": [
-            0.01574258391097035, 0.22402817027970748
+            0.016, 0.224
         ],
         "cpk_interval": [
-            -0.0006864277753152716, 0.1649324261093663
-        ]
+            -0.001, 0.165
+        ],
+        "error": null
     },
     "file324": {
         "data": [
@@ -5427,14 +5839,15 @@
         "lower_extreme": null,
         "upper_specification": 45.03,
         "lower_specification": 45.01,
-        "cp_point": 0.14243668337942555,
-        "cpk_point": 0.029656106427417835,
+        "cp_point": 0.142,
+        "cpk_point": 0.03,
         "cp_interval": [
-            0.02020639968631088, 0.2704136022814555
+            0.02, 0.27
         ],
         "cpk_interval": [
-            -0.02306915485771172, 0.0984132913763248
-        ]
+            -0.023, 0.098
+        ],
+        "error": null
     },
     "file325": {
         "data": [
@@ -5444,14 +5857,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 50.0,
         "lower_specification": null,
-        "cp_point": 2.552348859076336,
-        "cpk_point": 0.6909804720484565,
+        "cp_point": 3.19,
+        "cpk_point": 4.247,
         "cp_interval": [
-            1.582847911765798, 3.3885004969816332
+            1.979, 4.236
         ],
         "cpk_interval": [
-            0.34972446167020393, 0.9365200190790939
-        ]
+            2.484, 5.764
+        ],
+        "error": null
     },
     "file326": {
         "data": [
@@ -5461,14 +5875,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 50.0,
         "lower_specification": null,
-        "cp_point": 2.9480176241761495,
-        "cpk_point": 0.6913238526116727,
+        "cp_point": 3.984,
+        "cpk_point": 4.543,
         "cp_interval": [
-            1.5408228560419683, 3.7206938447207625
+            2.082, 5.028
         ],
         "cpk_interval": [
-            0.2910740379815479, 1.025183181391684
-        ]
+            2.214, 11.116
+        ],
+        "error": null
     },
     "file327": {
         "data": [
@@ -5478,14 +5893,15 @@
         "lower_extreme": null,
         "upper_specification": 45.36,
         "lower_specification": 45.34,
-        "cp_point": 0.9069024867082371,
-        "cpk_point": 0.4451699872147145,
+        "cp_point": 0.907,
+        "cpk_point": 0.445,
         "cp_interval": [
-            0.004856380549458606, 1.21684105413185
+            0.005, 1.217
         ],
         "cpk_interval": [
-            1.2372030827683951e-07, 0.6809349938621988
-        ]
+            0.0, 0.681
+        ],
+        "error": null
     },
     "file328": {
         "data": [
@@ -5495,14 +5911,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 20.0,
         "lower_specification": null,
-        "cp_point": 2.4188645369169737,
-        "cpk_point": 0.5254935855782558,
+        "cp_point": 4.838,
+        "cpk_point": 4.578,
         "cp_interval": [
-            1.2244849700856617, 3.4921364509404342
+            2.449, 6.984
         ],
         "cpk_interval": [
-            0.16418529234220625, 0.8497556983025656
-        ]
+            2.475, 6.267
+        ],
+        "error": null
     },
     "file329": {
         "data": [
@@ -5512,14 +5929,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 20.0,
         "lower_specification": null,
-        "cp_point": 1.8399966769275626,
-        "cpk_point": 0.849925594087477,
+        "cp_point": 2.453,
+        "cpk_point": 4.654,
         "cp_interval": [
-            1.2114796165472752, 2.1209485983577165
+            1.615, 2.828
         ],
         "cpk_interval": [
-            0.24705471103445964, 0.9780101379311837
-        ]
+            1.727, 7.761
+        ],
+        "error": null
     },
     "file330": {
         "data": [
@@ -5529,14 +5947,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.6450247249624883,
-        "cpk_point": 0.5351794795666334,
+        "cp_point": 2.924,
+        "cpk_point": 2.985,
         "cp_interval": [
-            0.8619451847197043, 2.370423641082894
+            1.532, 4.214
         ],
         "cpk_interval": [
-            0.1827565399885596, 0.8632406020812284
-        ]
+            1.661, 3.999
+        ],
+        "error": null
     },
     "file331": {
         "data": [
@@ -5546,14 +5965,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 2.852453292294521,
-        "cpk_point": 0.5703720174938176,
+        "cp_point": 4.564,
+        "cpk_point": 5.138,
         "cp_interval": [
-            1.4659373176809691, 4.027336512785652
+            2.345, 6.444
         ],
         "cpk_interval": [
-            0.1995232637763478, 0.8969681462014166
-        ]
+            2.654, 7.099
+        ],
+        "error": null
     },
     "file332": {
         "data": [
@@ -5563,14 +5983,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 25.0,
         "lower_specification": null,
-        "cp_point": 0.27760126547799985,
-        "cpk_point": 0.06999724058262444,
+        "cp_point": 0.868,
+        "cpk_point": 0.07,
         "cp_interval": [
-            0.12434233417746036, 0.41050243245746026
+            0.389, 1.283
         ],
         "cpk_interval": [
-            -0.07966573812246126, 0.24775412212993178
-        ]
+            -0.08, 0.252
+        ],
+        "error": null
     },
     "file333": {
         "data": [
@@ -5580,14 +6001,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 25.0,
         "lower_specification": null,
-        "cp_point": 0.03656600617255245,
-        "cpk_point": -0.7372910546391617,
+        "cp_point": 1.371,
+        "cpk_point": -0.737,
         "cp_interval": [
-            0.01655405780049171, 0.04693414166100832
+            0.621, 1.76
         ],
         "cpk_interval": [
-            -1.4896031362125886, -0.05286826774841479
-        ]
+            -1.49, -0.053
+        ],
+        "error": null
     },
     "file334": {
         "data": [
@@ -5597,14 +6019,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.3200688236169067,
-        "cpk_point": 0.794394170053849,
+        "cp_point": 1.515,
+        "cpk_point": 1.719,
         "cp_interval": [
-            0.9966590532083173, 1.6231423765245825
+            1.144, 1.863
         ],
         "cpk_interval": [
-            0.653543963773698, 0.9252080789419637
-        ]
+            1.193, 2.21
+        ],
+        "error": null
     },
     "file335": {
         "data": [
@@ -5614,14 +6037,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.42194951681022297,
-        "cpk_point": 0.38052516717091484,
+        "cp_point": 0.427,
+        "cpk_point": 0.381,
         "cp_interval": [
-            0.10075318157463535, 1.0995161349237252
+            0.102, 1.113
         ],
         "cpk_interval": [
-            0.08577474475591652, 0.9557417510712501
-        ]
+            0.086, 1.139
+        ],
+        "error": null
     },
     "file336": {
         "data": [
@@ -5630,7 +6054,16 @@
         "upper_extreme": null,
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
-        "lower_specification": null
+        "lower_specification": null,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More unique values are required to calculate capability indexes."
     },
     "file337": {
         "data": [
@@ -5640,14 +6073,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 2.0303872239110947,
-        "cpk_point": 1.213223876313785,
+        "cp_point": 2.03,
+        "cpk_point": 1.213,
         "cp_interval": [
-            1.3859945431307474, 2.594563011795661
+            1.386, 2.595
         ],
         "cpk_interval": [
-            0.9066347704677875, 1.4676960890485462
-        ]
+            0.907, 1.468
+        ],
+        "error": null
     },
     "file338": {
         "data": [
@@ -5657,14 +6091,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 2.2342457571474728,
-        "cpk_point": -0.725171786573414,
+        "cp_point": 2.234,
+        "cpk_point": -0.725,
         "cp_interval": [
-            1.6136915343873044, 2.8044932473946647
+            1.614, 2.804
         ],
         "cpk_interval": [
-            -0.8992989422217039, -0.48750042915051567
-        ]
+            -0.899, -0.488
+        ],
+        "error": null
     },
     "file339": {
         "data": [
@@ -5674,14 +6109,15 @@
         "lower_extreme": null,
         "upper_specification": 10.0,
         "lower_specification": 2.0,
-        "cp_point": 1.7199164509805,
-        "cpk_point": -0.03205159129995482,
+        "cp_point": 1.72,
+        "cpk_point": -0.032,
         "cp_interval": [
-            1.31392245371173, 2.0913695122140528
+            1.314, 2.091
         ],
         "cpk_interval": [
-            -0.11533309936127686, 0.05481528967127139
-        ]
+            -0.115, 0.055
+        ],
+        "error": null
     },
     "file340": {
         "data": [
@@ -5691,14 +6127,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 2.132012863198887,
-        "cpk_point": 0.47375196823660964,
+        "cp_point": 2.132,
+        "cpk_point": 0.474,
         "cp_interval": [
-            1.5151226450238016, 2.65813705285422
+            1.515, 2.658
         ],
         "cpk_interval": [
-            0.28702833390943117, 0.6260735563432417
-        ]
+            0.287, 0.626
+        ],
+        "error": null
     },
     "file341": {
         "data": [
@@ -5708,14 +6145,15 @@
         "lower_extreme": null,
         "upper_specification": 17.0,
         "lower_specification": 9.0,
-        "cp_point": 0.27433533474624533,
-        "cpk_point": 0.21798578430854415,
+        "cp_point": 0.274,
+        "cpk_point": 0.218,
         "cp_interval": [
-            0.11146869036338022, 0.40794115591460356
+            0.111, 0.408
         ],
         "cpk_interval": [
-            0.07408930029000972, 0.3513589289493586
-        ]
+            0.074, 0.351
+        ],
+        "error": null
     },
     "file342": {
         "data": [
@@ -5725,14 +6163,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 2.1390586765462105,
-        "cpk_point": -0.6291039909854923,
+        "cp_point": 2.139,
+        "cpk_point": -0.629,
         "cp_interval": [
-            1.5439146172347595, 2.6849189010807093
+            1.544, 2.685
         ],
         "cpk_interval": [
-            -0.7848642368177534, -0.41949210169737944
-        ]
+            -0.785, -0.419
+        ],
+        "error": null
     },
     "file343": {
         "data": [
@@ -5742,14 +6181,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 3.0,
-        "cp_point": 1.5445432294599957,
-        "cpk_point": 0.5281641436465769,
+        "cp_point": 1.545,
+        "cpk_point": 0.528,
         "cp_interval": [
-            1.0397096781627941, 1.8102549084871118
+            1.04, 1.81
         ],
         "cpk_interval": [
-            0.3088489186386102, 0.6769892425805727
-        ]
+            0.309, 0.677
+        ],
+        "error": null
     },
     "file344": {
         "data": [
@@ -5759,14 +6199,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 3.0,
-        "cp_point": 0.8325504331845868,
-        "cpk_point": 0.48113638747386384,
+        "cp_point": 0.833,
+        "cpk_point": 0.481,
         "cp_interval": [
-            0.6107927984740849, 0.9342220488469773
+            0.611, 0.934
         ],
         "cpk_interval": [
-            0.330272002190857, 0.5674258105496751
-        ]
+            0.33, 0.567
+        ],
+        "error": null
     },
     "file345": {
         "data": [
@@ -5776,14 +6217,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": 2.0,
-        "cp_point": 2.2951474303311588,
-        "cpk_point": 2.1008848914179534,
+        "cp_point": 2.295,
+        "cpk_point": 2.101,
         "cp_interval": [
-            1.5656900128423907, 2.6949525082449575
+            1.566, 2.695
         ],
         "cpk_interval": [
-            1.3725033198370364, 2.5029281170054207
-        ]
+            1.373, 2.503
+        ],
+        "error": null
     },
     "file346": {
         "data": [
@@ -5793,14 +6235,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": 2.0,
-        "cp_point": 2.0593189156150022,
-        "cpk_point": 1.6125759738881014,
+        "cp_point": 2.059,
+        "cpk_point": 1.613,
         "cp_interval": [
-            1.418841080270482, 2.6067010841446563
+            1.419, 2.607
         ],
         "cpk_interval": [
-            1.0420863463477947, 2.0781104814080393
-        ]
+            1.042, 2.078
+        ],
+        "error": null
     },
     "file347": {
         "data": [
@@ -5810,14 +6253,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 0.8613042134099034,
-        "cpk_point": 0.7862798893921452,
+        "cp_point": 0.893,
+        "cpk_point": 0.865,
         "cp_interval": [
-            0.07704344244590094, 2.4115130046879023
+            0.08, 2.499
         ],
         "cpk_interval": [
-            0.07387033190998576, 0.876751317383797
-        ]
+            0.074, 2.618
+        ],
+        "error": null
     },
     "file348": {
         "data": [
@@ -5827,14 +6271,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 6.035592177926354,
-        "cpk_point": 0.7476533400212105,
+        "cp_point": 6.257,
+        "cpk_point": 9.533,
         "cp_interval": [
-            4.3416582493410285, 6.997499392135507
+            4.501, 7.254
         ],
         "cpk_interval": [
-            0.6030230515405264, 0.8940553408956299
-        ]
+            5.943, 12.852
+        ],
+        "error": null
     },
     "file349": {
         "data": [
@@ -5844,14 +6289,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 1.0114889891859526,
-        "cpk_point": 0.7194759988474936,
+        "cp_point": 1.091,
+        "cpk_point": 1.039,
         "cp_interval": [
-            0.1607657104860995, 2.2700968987335863
+            0.173, 2.449
         ],
         "cpk_interval": [
-            0.15314726128050504, 0.8216581350925893
-        ]
+            0.153, 2.567
+        ],
+        "error": null
     },
     "file350": {
         "data": [
@@ -5861,14 +6307,15 @@
         "lower_extreme": null,
         "upper_specification": 65.49,
         "lower_specification": 65.22,
-        "cp_point": 3.164574945833358,
-        "cpk_point": 3.0884715576920514,
+        "cp_point": 3.165,
+        "cpk_point": 3.088,
         "cp_interval": [
-            2.214702737357169, 3.9729885726339855
+            2.215, 3.973
         ],
         "cpk_interval": [
-            2.0458427693850347, 3.9295874455238433
-        ]
+            2.046, 3.93
+        ],
+        "error": null
     },
     "file351": {
         "data": [
@@ -5878,14 +6325,15 @@
         "lower_extreme": null,
         "upper_specification": 78.2,
         "lower_specification": 78.05,
-        "cp_point": 1.2192259595728152,
-        "cpk_point": 0.8446625353812878,
+        "cp_point": 1.219,
+        "cpk_point": 0.845,
         "cp_interval": [
-            0.8148257279822838, 1.5727745524255237
+            0.815, 1.573
         ],
         "cpk_interval": [
-            0.5283928983827113, 1.2040746032642684
-        ]
+            0.528, 1.204
+        ],
+        "error": null
     },
     "file352": {
         "data": [
@@ -5895,14 +6343,15 @@
         "lower_extreme": null,
         "upper_specification": 77.046,
         "lower_specification": 76.985,
-        "cp_point": 0.436126271053847,
-        "cpk_point": 0.2600559951553296,
+        "cp_point": 0.436,
+        "cpk_point": 0.26,
         "cp_interval": [
-            0.31583944328136526, 0.5409761751247781
+            0.316, 0.541
         ],
         "cpk_interval": [
-            0.10293756492712036, 0.3761685832104854
-        ]
+            0.103, 0.376
+        ],
+        "error": null
     },
     "file353": {
         "data": [
@@ -5912,14 +6361,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": -5.0,
-        "cp_point": 1.6522747546741023,
-        "cpk_point": 0.8293398913154095,
+        "cp_point": 1.652,
+        "cpk_point": 0.829,
         "cp_interval": [
-            1.2463566996610693, 2.002820719118664
+            1.246, 2.003
         ],
         "cpk_interval": [
-            0.6377241555352664, 1.0313853264833637
-        ]
+            0.638, 1.031
+        ],
+        "error": null
     },
     "file354": {
         "data": [
@@ -5929,14 +6379,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": -5.0,
-        "cp_point": 0.799562530626136,
-        "cpk_point": 0.4293744510578829,
+        "cp_point": 0.8,
+        "cpk_point": 0.429,
         "cp_interval": [
-            0.4955781375513828, 0.9474219265760273
+            0.496, 0.947
         ],
         "cpk_interval": [
-            0.2357408329966213, 0.5440042938988507
-        ]
+            0.236, 0.544
+        ],
+        "error": null
     },
     "file355": {
         "data": [
@@ -5946,14 +6397,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 1.5204849490996144,
-        "cpk_point": 1.3859039525663581,
+        "cp_point": 1.52,
+        "cpk_point": 1.386,
         "cp_interval": [
-            0.8484792988378366, 2.264406880092958
+            0.848, 2.264
         ],
         "cpk_interval": [
-            0.7756907459317479, 2.028596281319024
-        ]
+            0.776, 2.029
+        ],
+        "error": null
     },
     "file356": {
         "data": [
@@ -5963,14 +6415,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 2.1322886466793065,
-        "cpk_point": 1.9671607846351604,
+        "cp_point": 2.132,
+        "cpk_point": 1.967,
         "cp_interval": [
-            1.546410564222373, 2.6741400228855094
+            1.546, 2.674
         ],
         "cpk_interval": [
-            1.414010187810922, 2.4611771218691496
-        ]
+            1.414, 2.461
+        ],
+        "error": null
     },
     "file357": {
         "data": [
@@ -5980,14 +6433,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.4274338336228275,
-        "cpk_point": -0.004424069768750919,
+        "cp_point": 1.099,
+        "cpk_point": -0.004,
         "cp_interval": [
-            0.3237094033305756, 0.5241051692707669
+            0.832, 1.348
         ],
         "cpk_interval": [
-            -0.10058515652394259, 0.09758527743381973
-        ]
+            -0.101, 0.098
+        ],
+        "error": null
     },
     "file358": {
         "data": [
@@ -5997,14 +6451,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.002105986503117534,
-        "cpk_point": 0.0009753538318576526,
+        "cp_point": 0.004,
+        "cpk_point": 0.001,
         "cp_interval": [
-            1.0105798312857746e-06, 0.03024442624158383
+            0.0, 0.062
         ],
         "cpk_interval": [
-            4.6341154202779806e-07, 0.017461148897757527
-        ]
+            0.0, 0.017
+        ],
+        "error": null
     },
     "file359": {
         "data": [
@@ -6014,14 +6469,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 2.096075963662021,
-        "cpk_point": 0.7158883147273742,
+        "cp_point": 2.351,
+        "cpk_point": 2.681,
         "cp_interval": [
-            1.39500837304391, 2.757243297147306
+            1.564, 3.092
         ],
         "cpk_interval": [
-            0.5437810360718027, 0.8360497881667858
-        ]
+            1.639, 3.739
+        ],
+        "error": null
     },
     "file360": {
         "data": [
@@ -6031,14 +6487,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 2.132304591795836,
-        "cpk_point": 0.7334514132987603,
+        "cp_point": 2.379,
+        "cpk_point": 2.752,
         "cp_interval": [
-            1.677023122350094, 2.564398634993475
+            1.871, 2.861
         ],
         "cpk_interval": [
-            0.6254139345483082, 0.8152465597121281
-        ]
+            2.056, 3.444
+        ],
+        "error": null
     },
     "file361": {
         "data": [
@@ -6048,14 +6505,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 2.7543718370396255,
-        "cpk_point": 0.9679275024182156,
+        "cp_point": 2.785,
+        "cpk_point": 4.382,
         "cp_interval": [
-            2.057875211797224, 3.0476002613253996
+            2.081, 3.082
         ],
         "cpk_interval": [
-            0.9351720484900302, 1.0151746126685393
-        ]
+            2.68, 5.31
+        ],
+        "error": null
     },
     "file362": {
         "data": [
@@ -6065,14 +6523,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 2.790342455487155,
-        "cpk_point": 0.9577971878229687,
+        "cp_point": 2.838,
+        "cpk_point": 4.617,
         "cp_interval": [
-            2.03141814840813, 3.0885241588534216
+            2.066, 3.141
         ],
         "cpk_interval": [
-            0.907592375553849, 1.0210866626498079
-        ]
+            2.865, 5.597
+        ],
+        "error": null
     },
     "file363": {
         "data": [
@@ -6082,14 +6541,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 2.3535539544522366,
-        "cpk_point": 0.5195641655961699,
+        "cp_point": 2.354,
+        "cpk_point": 0.52,
         "cp_interval": [
-            1.8706264606204643, 2.7326928788445817
+            1.871, 2.733
         ],
         "cpk_interval": [
-            0.3755674306334029, 0.6658990504844156
-        ]
+            0.376, 0.666
+        ],
+        "error": null
     },
     "file364": {
         "data": [
@@ -6099,14 +6559,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 1.4533440610505353,
-        "cpk_point": 0.3759297778821219,
+        "cp_point": 1.453,
+        "cpk_point": 0.376,
         "cp_interval": [
-            1.2310075189319736, 1.6080682274609852
+            1.231, 1.608
         ],
         "cpk_interval": [
-            0.2782073827999634, 0.43975415442726123
-        ]
+            0.278, 0.44
+        ],
+        "error": null
     },
     "file365": {
         "data": [
@@ -6116,14 +6577,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 1.7629800580502675,
-        "cpk_point": 0.4052193253506221,
+        "cp_point": 1.763,
+        "cpk_point": 0.405,
         "cp_interval": [
-            1.3874775488127469, 2.1604398387871195
+            1.387, 2.16
         ],
         "cpk_interval": [
-            0.2877767743348468, 0.5292348028983731
-        ]
+            0.288, 0.529
+        ],
+        "error": null
     },
     "file366": {
         "data": [
@@ -6133,14 +6595,15 @@
         "lower_extreme": null,
         "upper_specification": 10.0,
         "lower_specification": 2.0,
-        "cp_point": 1.5384404442283823,
-        "cpk_point": 0.2352070491199681,
+        "cp_point": 1.538,
+        "cpk_point": 0.235,
         "cp_interval": [
-            1.2256257836389022, 1.7990667488195853
+            1.226, 1.799
         ],
         "cpk_interval": [
-            0.1571322173871814, 0.3393378669616919
-        ]
+            0.157, 0.339
+        ],
+        "error": null
     },
     "file367": {
         "data": [
@@ -6150,14 +6613,15 @@
         "lower_extreme": null,
         "upper_specification": 17.0,
         "lower_specification": 9.0,
-        "cp_point": 1.371015601682071,
-        "cpk_point": 0.6783349287534727,
+        "cp_point": 1.371,
+        "cpk_point": 0.678,
         "cp_interval": [
-            1.1341525824879024, 1.5927454474531981
+            1.134, 1.593
         ],
         "cpk_interval": [
-            0.5465366789084087, 0.7832766231153171
-        ]
+            0.547, 0.783
+        ],
+        "error": null
     },
     "file368": {
         "data": [
@@ -6167,14 +6631,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 2.941368563618085,
-        "cpk_point": -1.3000361180449413,
+        "cp_point": 2.941,
+        "cpk_point": -1.3,
         "cp_interval": [
-            2.4011584201549825, 3.444749983983042
+            2.401, 3.445
         ],
         "cpk_interval": [
-            -1.5358432338388728, -1.0323860150008606
-        ]
+            -1.536, -1.032
+        ],
+        "error": null
     },
     "file369": {
         "data": [
@@ -6184,14 +6649,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 3.0,
-        "cp_point": 1.110192054906989,
-        "cpk_point": 0.31792103299412655,
+        "cp_point": 1.11,
+        "cpk_point": 0.318,
         "cp_interval": [
-            0.8939117534383108, 1.2979492475261099
+            0.894, 1.298
         ],
         "cpk_interval": [
-            0.22024644926404838, 0.4004751661520481
-        ]
+            0.22, 0.4
+        ],
+        "error": null
     },
     "file370": {
         "data": [
@@ -6201,14 +6667,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 3.0,
-        "cp_point": 1.598400051345731,
-        "cpk_point": 1.189888699664355,
+        "cp_point": 1.598,
+        "cpk_point": 1.19,
         "cp_interval": [
-            1.2544224749800195, 1.7923419277307147
+            1.254, 1.792
         ],
         "cpk_interval": [
-            0.8458665846446507, 1.3600690172252794
-        ]
+            0.846, 1.36
+        ],
+        "error": null
     },
     "file371": {
         "data": [
@@ -6218,14 +6685,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": 2.0,
-        "cp_point": 1.1259702100308049,
-        "cpk_point": 0.6850757575867015,
+        "cp_point": 1.126,
+        "cpk_point": 0.685,
         "cp_interval": [
-            0.8078603032783053, 1.4267012608380039
+            0.808, 1.427
         ],
         "cpk_interval": [
-            0.5094082418426106, 0.8717137089268836
-        ]
+            0.509, 0.872
+        ],
+        "error": null
     },
     "file372": {
         "data": [
@@ -6235,14 +6703,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": 2.0,
-        "cp_point": 2.269239721351666,
-        "cpk_point": 1.7746159665893255,
+        "cp_point": 2.269,
+        "cpk_point": 1.775,
         "cp_interval": [
-            1.7835640821721663, 2.563614465212679
+            1.784, 2.564
         ],
         "cpk_interval": [
-            1.312802243792125, 2.089431501073875
-        ]
+            1.313, 2.089
+        ],
+        "error": null
     },
     "file373": {
         "data": [
@@ -6252,14 +6721,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 5.343848910893178,
-        "cpk_point": 0.8069377317051454,
+        "cp_point": 5.529,
+        "cpk_point": 7.909,
         "cp_interval": [
-            4.282998642647276, 6.262845608657863
+            4.431, 6.48
         ],
         "cpk_interval": [
-            0.6875090551488744, 0.9078950504179862
-        ]
+            5.52, 10.452
+        ],
+        "error": null
     },
     "file374": {
         "data": [
@@ -6269,14 +6739,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 3.4855051182251393,
-        "cpk_point": 0.7785023647805506,
+        "cp_point": 3.606,
+        "cpk_point": 4.296,
         "cp_interval": [
-            2.5533422031412285, 4.434039820727941
+            2.642, 4.587
         ],
         "cpk_interval": [
-            0.6751557100452562, 0.8538131060924814
-        ]
+            2.972, 5.682
+        ],
+        "error": null
     },
     "file375": {
         "data": [
@@ -6286,14 +6757,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 2.394525874397387,
-        "cpk_point": 0.9909731443390564,
+        "cp_point": 2.489,
+        "cpk_point": 2.736,
         "cp_interval": [
-            1.5852535865177197, 3.2421899536056484
+            1.648, 3.37
         ],
         "cpk_interval": [
-            0.882028538828523, 1.0744112756479025
-        ]
+            1.701, 3.898
+        ],
+        "error": null
     },
     "file376": {
         "data": [
@@ -6303,14 +6775,15 @@
         "lower_extreme": null,
         "upper_specification": 65.49,
         "lower_specification": 65.22,
-        "cp_point": 3.3297908480087357,
-        "cpk_point": 3.2158049253667595,
+        "cp_point": 3.33,
+        "cpk_point": 3.216,
         "cp_interval": [
-            2.6161259269344694, 3.943626612267051
+            2.616, 3.944
         ],
         "cpk_interval": [
-            2.438249460350385, 3.90102458207299
-        ]
+            2.438, 3.901
+        ],
+        "error": null
     },
     "file377": {
         "data": [
@@ -6320,14 +6793,15 @@
         "lower_extreme": null,
         "upper_specification": 78.2,
         "lower_specification": 78.05,
-        "cp_point": 1.594335298908,
-        "cpk_point": 1.5250009451117708,
+        "cp_point": 1.594,
+        "cpk_point": 1.525,
         "cp_interval": [
-            1.2459851631746521, 1.8950693735890598
+            1.246, 1.895
         ],
         "cpk_interval": [
-            1.1481830930264607, 1.8305050205740667
-        ]
+            1.148, 1.831
+        ],
+        "error": null
     },
     "file378": {
         "data": [
@@ -6337,14 +6811,15 @@
         "lower_extreme": null,
         "upper_specification": 77.046,
         "lower_specification": 76.985,
-        "cp_point": 0.22209426293816176,
-        "cpk_point": 0.06340542683039008,
+        "cp_point": 0.222,
+        "cpk_point": 0.063,
         "cp_interval": [
-            0.16185008549998764, 0.29002653986492255
+            0.162, 0.29
         ],
         "cpk_interval": [
-            0.004103365892020291, 0.11209979884034485
-        ]
+            0.004, 0.112
+        ],
+        "error": null
     },
     "file379": {
         "data": [
@@ -6354,14 +6829,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": -5.0,
-        "cp_point": 1.3711336602658166,
-        "cpk_point": 0.8297800337332083,
+        "cp_point": 1.371,
+        "cpk_point": 0.83,
         "cp_interval": [
-            1.0730926471326268, 1.627028609613793
+            1.073, 1.627
         ],
         "cpk_interval": [
-            0.6965579652913567, 0.9707981838460228
-        ]
+            0.697, 0.971
+        ],
+        "error": null
     },
     "file380": {
         "data": [
@@ -6371,14 +6847,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": -5.0,
-        "cp_point": 1.2560666226638715,
-        "cpk_point": 0.4915503449891529,
+        "cp_point": 1.256,
+        "cpk_point": 0.492,
         "cp_interval": [
-            1.0299837095155435, 1.4564148270701736
+            1.03, 1.456
         ],
         "cpk_interval": [
-            0.37813904337619664, 0.6261507151973722
-        ]
+            0.378, 0.626
+        ],
+        "error": null
     },
     "file381": {
         "data": [
@@ -6388,14 +6865,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 1.4901236252082326,
-        "cpk_point": 1.4545473348372993,
+        "cp_point": 1.49,
+        "cpk_point": 1.455,
         "cp_interval": [
-            1.1571947379196057, 1.779429210683997
+            1.157, 1.779
         ],
         "cpk_interval": [
-            1.0829927675595803, 1.739762398565795
-        ]
+            1.083, 1.74
+        ],
+        "error": null
     },
     "file382": {
         "data": [
@@ -6405,14 +6883,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 1.9568131657930392,
-        "cpk_point": 1.8093026068860236,
+        "cp_point": 1.957,
+        "cpk_point": 1.809,
         "cp_interval": [
-            1.5371005087182243, 2.3198093863199727
+            1.537, 2.32
         ],
         "cpk_interval": [
-            1.3607186663510538, 2.1761252844727332
-        ]
+            1.361, 2.176
+        ],
+        "error": null
     },
     "file383": {
         "data": [
@@ -6422,14 +6901,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.21904761185090815,
-        "cpk_point": -0.0276761803405362,
+        "cp_point": 0.657,
+        "cpk_point": -0.028,
         "cp_interval": [
-            0.007304405474442552, 0.3368612757267063
+            0.022, 1.011
         ],
         "cpk_interval": [
-            -0.07765536616919347, 0.005679349605331367
-        ]
+            -0.078, 0.006
+        ],
+        "error": null
     },
     "file384": {
         "data": [
@@ -6439,14 +6919,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.5620112174482176,
-        "cpk_point": 0.4355478248429605,
+        "cp_point": 1.146,
+        "cpk_point": 0.436,
         "cp_interval": [
-            0.47655221708749906, 0.63387191290233
+            0.972, 1.292
         ],
         "cpk_interval": [
-            0.2403492790916323, 0.5403745637672249
-        ]
+            0.24, 0.54
+        ],
+        "error": null
     },
     "file385": {
         "data": [
@@ -6456,14 +6937,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.9200505747703804,
-        "cpk_point": 0.7452594939105053,
+        "cp_point": 2.143,
+        "cpk_point": 2.368,
         "cp_interval": [
-            1.4673285438688333, 2.36083862661821
+            1.637, 2.634
         ],
         "cpk_interval": [
-            0.6379650147688611, 0.8257463860241782
-        ]
+            1.714, 3.046
+        ],
+        "error": null
     },
     "file386": {
         "data": [
@@ -6473,14 +6955,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.676017354441955,
-        "cpk_point": 0.9027386058184755,
+        "cp_point": 2.676,
+        "cpk_point": 0.903,
         "cp_interval": [
-            1.5178984445102603, 3.6561967161689117
+            1.518, 3.656
         ],
         "cpk_interval": [
-            0.47833279923094796, 1.3026993086468295
-        ]
+            0.478, 1.303
+        ],
+        "error": null
     },
     "file387": {
         "data": [
@@ -6490,14 +6973,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.1588326092269057,
-        "cpk_point": 0.6392458307676585,
+        "cp_point": 2.159,
+        "cpk_point": 0.639,
         "cp_interval": [
-            1.098757752263734, 2.966372501373312
+            1.099, 2.966
         ],
         "cpk_interval": [
-            0.35435494004268375, 0.9100755679267339
-        ]
+            0.354, 0.91
+        ],
+        "error": null
     },
     "file388": {
         "data": [
@@ -6507,14 +6991,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.419973088338351,
-        "cpk_point": 0.7320299885425916,
+        "cp_point": 2.42,
+        "cpk_point": 0.732,
         "cp_interval": [
-            1.1882088990826907, 3.3393173797571656
+            1.188, 3.339
         ],
         "cpk_interval": [
-            0.4263493546429816, 1.0176734009951478
-        ]
+            0.426, 1.018
+        ],
+        "error": null
     },
     "file389": {
         "data": [
@@ -6524,14 +7009,15 @@
         "lower_extreme": null,
         "upper_specification": 12.0,
         "lower_specification": 4.0,
-        "cp_point": 3.0498897650119154,
-        "cpk_point": 2.0742251002458714,
+        "cp_point": 3.05,
+        "cpk_point": 2.074,
         "cp_interval": [
-            2.1458927224000637, 3.694993472168913
+            2.146, 3.695
         ],
         "cpk_interval": [
-            1.5435416323000304, 2.722198472646811
-        ]
+            1.544, 2.722
+        ],
+        "error": null
     },
     "file390": {
         "data": [
@@ -6541,14 +7027,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.072329195860821,
-        "cpk_point": 0.9608067947718427,
+        "cp_point": 2.072,
+        "cpk_point": 0.961,
         "cp_interval": [
-            0.9595264197548443, 2.9110347300729575
+            0.96, 2.911
         ],
         "cpk_interval": [
-            0.5946935623455315, 1.296997109741851
-        ]
+            0.595, 1.297
+        ],
+        "error": null
     },
     "file391": {
         "data": [
@@ -6558,14 +7045,15 @@
         "lower_extreme": null,
         "upper_specification": 20.0,
         "lower_specification": 10.0,
-        "cp_point": 4.773846207367379,
-        "cpk_point": 4.3177048090955505,
+        "cp_point": 4.774,
+        "cpk_point": 4.318,
         "cp_interval": [
-            3.3421813827272975, 6.02306221603436
+            3.342, 6.023
         ],
         "cpk_interval": [
-            2.867046331046, 5.575616036943064
-        ]
+            2.867, 5.576
+        ],
+        "error": null
     },
     "file392": {
         "data": [
@@ -6574,7 +7062,16 @@
         "upper_extreme": null,
         "lower_extreme": null,
         "upper_specification": 5.0,
-        "lower_specification": 1.0
+        "lower_specification": 1.0,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More unique values are required to calculate capability indexes."
     },
     "file393": {
         "data": [
@@ -6584,14 +7081,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 2.436389324064074,
-        "cpk_point": 1.5844208962778523,
+        "cp_point": 2.436,
+        "cpk_point": 1.584,
         "cp_interval": [
-            1.6889598728064594, 3.114152454183065
+            1.689, 3.114
         ],
         "cpk_interval": [
-            1.0413616743809426, 2.114346835275492
-        ]
+            1.041, 2.114
+        ],
+        "error": null
     },
     "file394": {
         "data": [
@@ -6600,7 +7098,16 @@
         "upper_extreme": null,
         "lower_extreme": null,
         "upper_specification": 5.0,
-        "lower_specification": 1.0
+        "lower_specification": 1.0,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More unique values are required to calculate capability indexes."
     },
     "file395": {
         "data": [
@@ -6610,14 +7117,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 2.220266033563277,
-        "cpk_point": 1.5516785283664618,
+        "cp_point": 2.22,
+        "cpk_point": 1.552,
         "cp_interval": [
-            1.5262540776087357, 2.837084197225281
+            1.526, 2.837
         ],
         "cpk_interval": [
-            1.0075905218899999, 2.088670294596565
-        ]
+            1.008, 2.089
+        ],
+        "error": null
     },
     "file396": {
         "data": [
@@ -6627,14 +7135,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 1.6717409124206517,
-        "cpk_point": 1.275477058991001,
+        "cp_point": 1.672,
+        "cpk_point": 1.275,
         "cp_interval": [
-            1.1813788924920428, 2.123802978121883
+            1.181, 2.124
         ],
         "cpk_interval": [
-            0.8947551456667955, 1.6494129062585932
-        ]
+            0.895, 1.649
+        ],
+        "error": null
     },
     "file397": {
         "data": [
@@ -6644,14 +7153,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 1.0,
-        "cp_point": 2.9091359897659803,
-        "cpk_point": 2.4996729329534424,
+        "cp_point": 2.909,
+        "cpk_point": 2.5,
         "cp_interval": [
-            2.0057969353460696, 3.7366219048197866
+            2.006, 3.737
         ],
         "cpk_interval": [
-            1.6382726664585543, 3.2887849778460714
-        ]
+            1.638, 3.289
+        ],
+        "error": null
     },
     "file398": {
         "data": [
@@ -6661,14 +7171,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 1.6794018197460543,
-        "cpk_point": 1.1967154968993445,
+        "cp_point": 1.679,
+        "cpk_point": 1.197,
         "cp_interval": [
-            1.1277315351813957, 2.158164586212805
+            1.128, 2.158
         ],
         "cpk_interval": [
-            0.7521384504827978, 1.6632535654561191
-        ]
+            0.752, 1.663
+        ],
+        "error": null
     },
     "file399": {
         "data": [
@@ -6678,14 +7189,15 @@
         "lower_extreme": null,
         "upper_specification": 18.0,
         "lower_specification": 12.0,
-        "cp_point": 2.5432897683003532,
-        "cpk_point": 2.1201507597370153,
+        "cp_point": 2.543,
+        "cpk_point": 2.12,
         "cp_interval": [
-            1.7440496973495132, 3.2630507022034303
+            1.744, 3.263
         ],
         "cpk_interval": [
-            1.3783455924976453, 2.82044157319642
-        ]
+            1.378, 2.82
+        ],
+        "error": null
     },
     "file400": {
         "data": [
@@ -6695,14 +7207,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 2.094319237813115,
-        "cpk_point": 0.7754916722168065,
+        "cp_point": 2.234,
+        "cpk_point": 2.791,
         "cp_interval": [
-            1.0102188321767849, 3.4074431985245752
+            1.078, 3.635
         ],
         "cpk_interval": [
-            0.6525659139713521, 0.9586409572019217
-        ]
+            1.091, 5.664
+        ],
+        "error": null
     },
     "file401": {
         "data": [
@@ -6712,14 +7225,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 2.776094421792605,
-        "cpk_point": 0.81036630163577,
+        "cp_point": 2.929,
+        "cpk_point": 3.837,
         "cp_interval": [
-            1.9775140874789578, 3.502693873575081
+            2.086, 3.695
         ],
         "cpk_interval": [
-            0.658691721983445, 0.9339478318074207
-        ]
+            2.482, 5.048
+        ],
+        "error": null
     },
     "file402": {
         "data": [
@@ -6729,14 +7243,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 0.9539274347009168,
-        "cpk_point": 0.7767491971215402,
+        "cp_point": 1.049,
+        "cpk_point": 1.027,
         "cp_interval": [
-            0.6396684995368094, 1.2546123009969534
+            0.704, 1.38
         ],
         "cpk_interval": [
-            0.5874694424115703, 0.8673484258901568
-        ]
+            0.618, 1.48
+        ],
+        "error": null
     },
     "file403": {
         "data": [
@@ -6746,14 +7261,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 1.9818788193594237,
-        "cpk_point": 0.5895908976333828,
+        "cp_point": 1.982,
+        "cpk_point": 0.59,
         "cp_interval": [
-            1.1707147684020662, 2.6710712616798493
+            1.171, 2.671
         ],
         "cpk_interval": [
-            0.30920466991016055, 0.8754207212671464
-        ]
+            0.309, 0.875
+        ],
+        "error": null
     },
     "file404": {
         "data": [
@@ -6763,14 +7279,15 @@
         "lower_extreme": null,
         "upper_specification": 42.2,
         "lower_specification": 41.95,
-        "cp_point": 2.85612634961265,
-        "cpk_point": 2.0992564387223744,
+        "cp_point": 2.856,
+        "cpk_point": 2.099,
         "cp_interval": [
-            1.9903797788517676, 3.615488388352586
+            1.99, 3.615
         ],
         "cpk_interval": [
-            1.5139086346075254, 2.6170347354246823
-        ]
+            1.514, 2.617
+        ],
+        "error": null
     },
     "file405": {
         "data": [
@@ -6780,14 +7297,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.868138045782087,
-        "cpk_point": 1.0189250931410743,
+        "cp_point": 2.868,
+        "cpk_point": 1.019,
         "cp_interval": [
-            1.686896234538074, 3.86619666677554
+            1.687, 3.866
         ],
         "cpk_interval": [
-            0.5775314655298048, 1.4431796214676735
-        ]
+            0.578, 1.443
+        ],
+        "error": null
     },
     "file406": {
         "data": [
@@ -6797,14 +7315,15 @@
         "lower_extreme": null,
         "upper_specification": 51.8,
         "lower_specification": 51.65,
-        "cp_point": 2.685601702127429,
-        "cpk_point": 2.4510045953126993,
+        "cp_point": 2.686,
+        "cpk_point": 2.451,
         "cp_interval": [
-            1.8108646459051365, 3.4301006154025164
+            1.811, 3.43
         ],
         "cpk_interval": [
-            1.5458453999449062, 3.2543920206596613
-        ]
+            1.546, 3.254
+        ],
+        "error": null
     },
     "file407": {
         "data": [
@@ -6814,14 +7333,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.3337597484633705,
-        "cpk_point": 0.8940471279727942,
+        "cp_point": 2.334,
+        "cpk_point": 0.894,
         "cp_interval": [
-            1.3644675481093, 3.1657195651886365
+            1.364, 3.166
         ],
         "cpk_interval": [
-            0.4866890130255834, 1.280211975333672
-        ]
+            0.487, 1.28
+        ],
+        "error": null
     },
     "file408": {
         "data": [
@@ -6831,14 +7351,15 @@
         "lower_extreme": null,
         "upper_specification": 50.876,
         "lower_specification": 50.819,
-        "cp_point": 2.380436736491522,
-        "cpk_point": 1.316314083837226,
+        "cp_point": 2.38,
+        "cpk_point": 1.316,
         "cp_interval": [
-            1.6763811923841185, 3.0315043092078513
+            1.676, 3.032
         ],
         "cpk_interval": [
-            0.9238992612465518, 1.6433534001426524
-        ]
+            0.924, 1.643
+        ],
+        "error": null
     },
     "file409": {
         "data": [
@@ -6848,14 +7369,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 3.27324656722488,
-        "cpk_point": 0.9823281503602435,
+        "cp_point": 3.273,
+        "cpk_point": 0.982,
         "cp_interval": [
-            1.9429792529571444, 4.396242672267252
+            1.943, 4.396
         ],
         "cpk_interval": [
-            0.5587389270960651, 1.3870602273095682
-        ]
+            0.559, 1.387
+        ],
+        "error": null
     },
     "file410": {
         "data": [
@@ -6865,14 +7387,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 4.125323569282161,
-        "cpk_point": 1.6772889135122033,
+        "cp_point": 4.125,
+        "cpk_point": 1.677,
         "cp_interval": [
-            2.9182124372185902, 5.254036425906423
+            2.918, 5.254
         ],
         "cpk_interval": [
-            1.165896184854362, 2.1512493899296383
-        ]
+            1.166, 2.151
+        ],
+        "error": null
     },
     "file411": {
         "data": [
@@ -6882,14 +7405,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 3.3812587483236634,
-        "cpk_point": 1.9849610562302051,
+        "cp_point": 3.381,
+        "cpk_point": 1.985,
         "cp_interval": [
-            2.319180685611145, 4.27933564041567
+            2.319, 4.279
         ],
         "cpk_interval": [
-            1.440469365951263, 2.463965922130988
-        ]
+            1.44, 2.464
+        ],
+        "error": null
     },
     "file412": {
         "data": [
@@ -6899,14 +7423,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 5.010577420966665,
-        "cpk_point": 4.2917975152974615,
+        "cp_point": 5.011,
+        "cpk_point": 4.292,
         "cp_interval": [
-            3.4942069408131644, 6.3364057455158225
+            3.494, 6.336
         ],
         "cpk_interval": [
-            3.116899756694088, 5.385219045709911
-        ]
+            3.117, 5.385
+        ],
+        "error": null
     },
     "file413": {
         "data": [
@@ -6916,14 +7441,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 2.3562141275131325,
-        "cpk_point": 1.5683505477450408,
+        "cp_point": 2.356,
+        "cpk_point": 1.568,
         "cp_interval": [
-            1.629099464941848, 3.010760184739227
+            1.629, 3.011
         ],
         "cpk_interval": [
-            1.0266507464923642, 2.099212896797732
-        ]
+            1.027, 2.099
+        ],
+        "error": null
     },
     "file414": {
         "data": [
@@ -6933,14 +7459,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.20552981189739203,
-        "cpk_point": 0.004518145849973748,
+        "cp_point": 1.363,
+        "cpk_point": 0.005,
         "cp_interval": [
-            0.1295227643595172, 0.2773712028264187
+            0.859, 1.839
         ],
         "cpk_interval": [
-            -0.07133744843538747, 0.0971111790234797
-        ]
+            -0.071, 0.097
+        ],
+        "error": null
     },
     "file415": {
         "data": [
@@ -6950,14 +7477,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.8998238027424803,
-        "cpk_point": 0.7297680280170707,
+        "cp_point": 1.102,
+        "cpk_point": 0.953,
         "cp_interval": [
-            0.5101372558625127, 1.2891431231867163
+            0.625, 1.579
         ],
         "cpk_interval": [
-            0.4748231700895218, 0.8436555698497757
-        ]
+            0.49, 1.504
+        ],
+        "error": null
     },
     "file416": {
         "data": [
@@ -6967,14 +7495,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.9007095826045808,
-        "cpk_point": 0.7488745002388288,
+        "cp_point": 1.015,
+        "cpk_point": 0.932,
         "cp_interval": [
-            0.41978059722191985, 1.4327593200777258
+            0.473, 1.614
         ],
         "cpk_interval": [
-            0.3964599241562228, 0.8525414595081514
-        ]
+            0.396, 1.624
+        ],
+        "error": null
     },
     "file417": {
         "data": [
@@ -6984,14 +7513,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.9490837281528484,
-        "cpk_point": 0.6519658543105782,
+        "cp_point": 1.38,
+        "cpk_point": 1.06,
         "cp_interval": [
-            0.54618450442809, 1.3358595347043136
+            0.794, 1.943
         ],
         "cpk_interval": [
-            0.4478322108220877, 0.7912501696335867
-        ]
+            0.551, 1.649
+        ],
+        "error": null
     },
     "file418": {
         "data": [
@@ -7001,14 +7531,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.4185850556332096,
-        "cpk_point": 0.7328490136572523,
+        "cp_point": 1.595,
+        "cpk_point": 1.612,
         "cp_interval": [
-            0.7633518089011706, 2.087877880394359
+            0.858, 2.347
         ],
         "cpk_interval": [
-            0.5510742708733991, 0.8550168383794858
-        ]
+            0.786, 2.572
+        ],
+        "error": null
     },
     "file419": {
         "data": [
@@ -7018,14 +7549,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.8872592730088158,
-        "cpk_point": 0.8782910023787609,
+        "cp_point": 1.987,
+        "cpk_point": 2.428,
         "cp_interval": [
-            1.3375112879786926, 2.3921811070831547
+            1.408, 2.518
         ],
         "cpk_interval": [
-            0.7549978531728235, 0.9881926480826404
-        ]
+            1.552, 3.258
+        ],
+        "error": null
     },
     "file420": {
         "data": [
@@ -7035,14 +7567,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 50.0,
         "lower_specification": null,
-        "cp_point": 1.6663169745696442,
-        "cpk_point": 0.6949450217722641,
+        "cp_point": 2.083,
+        "cpk_point": 2.569,
         "cp_interval": [
-            1.177455515904575, 2.087224305856285
+            1.472, 2.609
         ],
         "cpk_interval": [
-            0.4538675123676588, 0.8791182266369202
-        ]
+            1.716, 3.323
+        ],
+        "error": null
     },
     "file421": {
         "data": [
@@ -7052,14 +7585,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 20.0,
         "lower_specification": null,
-        "cp_point": 1.4925528496894942,
-        "cpk_point": 0.653951398982074,
+        "cp_point": 2.673,
+        "cpk_point": 2.02,
         "cp_interval": [
-            0.9364246925959107, 1.996242607428015
+            1.677, 3.575
         ],
         "cpk_interval": [
-            0.3905386908685109, 0.827706294389851
-        ]
+            1.177, 2.864
+        ],
+        "error": null
     },
     "file422": {
         "data": [
@@ -7069,14 +7603,15 @@
         "lower_extreme": null,
         "upper_specification": 45.36,
         "lower_specification": 45.34,
-        "cp_point": 0.7571834425818501,
-        "cpk_point": 0.45132994923876496,
+        "cp_point": 0.757,
+        "cpk_point": 0.451,
         "cp_interval": [
-            0.20265955342276634, 0.9120419040108476
+            0.203, 0.912
         ],
         "cpk_interval": [
-            0.16224353914519143, 0.6294198632982966
-        ]
+            0.162, 0.629
+        ],
+        "error": null
     },
     "file423": {
         "data": [
@@ -7086,14 +7621,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 20.0,
         "lower_specification": null,
-        "cp_point": 1.9696941950343683,
-        "cpk_point": 0.6924419528785322,
+        "cp_point": 2.437,
+        "cpk_point": 2.684,
         "cp_interval": [
-            1.2550849652830536, 2.624696092682206
+            1.553, 3.247
         ],
         "cpk_interval": [
-            0.4465079922060102, 0.8549008336896581
-        ]
+            1.566, 3.787
+        ],
+        "error": null
     },
     "file424": {
         "data": [
@@ -7103,14 +7639,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 2.02838671753072,
-        "cpk_point": 0.5396722753138464,
+        "cp_point": 3.859,
+        "cpk_point": 2.833,
         "cp_interval": [
-            1.0906967669118324, 2.8162806947693353
+            2.075, 5.359
         ],
         "cpk_interval": [
-            0.3036687647394651, 0.701128309699468
-        ]
+            1.341, 4.23
+        ],
+        "error": null
     },
     "file425": {
         "data": [
@@ -7120,14 +7657,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 2.211736017355103,
-        "cpk_point": 0.5686050237385577,
+        "cp_point": 3.765,
+        "cpk_point": 3.081,
         "cp_interval": [
-            1.1861145599168144, 3.073677642579972
+            2.019, 5.232
         ],
         "cpk_interval": [
-            0.32750300515978203, 0.7289074047549211
-        ]
+            1.453, 4.609
+        ],
+        "error": null
     },
     "file426": {
         "data": [
@@ -7137,14 +7675,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 25.0,
         "lower_specification": null,
-        "cp_point": 0.2007737126502914,
-        "cpk_point": -0.14125781800521917,
+        "cp_point": 0.717,
+        "cpk_point": -0.141,
         "cp_interval": [
-            0.1317148513205114, 0.262586872088759
+            0.47, 0.938
         ],
         "cpk_interval": [
-            -0.2502865343483381, -0.0010942575464208924
-        ]
+            -0.25, -0.001
+        ],
+        "error": null
     },
     "file427": {
         "data": [
@@ -7154,14 +7693,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 25.0,
         "lower_specification": null,
-        "cp_point": 0.007288732140520023,
-        "cpk_point": -0.6895421210756488,
+        "cp_point": 1.093,
+        "cpk_point": -0.69,
         "cp_interval": [
-            0.004694494631283118, 0.009016413119491135
+            0.704, 1.352
         ],
         "cpk_interval": [
-            -1.1034842420237683, -0.1665471361421845
-        ]
+            -1.103, -0.167
+        ],
+        "error": null
     },
     "file428": {
         "data": [
@@ -7171,14 +7711,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 20.0,
         "lower_specification": null,
-        "cp_point": 1.1084367737458507,
-        "cpk_point": 0.6487676211650301,
+        "cp_point": 1.462,
+        "cpk_point": 1.25,
         "cp_interval": [
-            0.41320667197348093, 1.7531162649228518
+            0.545, 2.312
         ],
         "cpk_interval": [
-            0.3227587147855699, 0.8169558357047224
-        ]
+            0.408, 2.171
+        ],
+        "error": null
     },
     "file429": {
         "data": [
@@ -7188,14 +7729,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 0.028303252335213053,
-        "cpk_point": -0.6150084531749933,
+        "cp_point": 2.264,
+        "cpk_point": -0.615,
         "cp_interval": [
-            0.01769207979345154, 0.038194042702044934
+            1.415, 3.056
         ],
         "cpk_interval": [
-            -0.871131626903197, -0.28375465876388184
-        ]
+            -0.871, -0.284
+        ],
+        "error": null
     },
     "file430": {
         "data": [
@@ -7205,14 +7747,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 0.6119447676885337,
-        "cpk_point": 0.5883514337537266,
+        "cp_point": 1.958,
+        "cpk_point": 0.588,
         "cp_interval": [
-            0.15344561388263478, 1.050309963690952
+            0.491, 3.361
         ],
         "cpk_interval": [
-            0.12832868015580273, 0.8741255508397605
-        ]
+            0.128, 1.157
+        ],
+        "error": null
     },
     "file431": {
         "data": [
@@ -7222,14 +7765,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 43.0,
         "lower_specification": null,
-        "cp_point": 0.4865873063115694,
-        "cpk_point": 0.3215333971046943,
+        "cp_point": 0.747,
+        "cpk_point": 0.322,
         "cp_interval": [
-            0.35643576800630034, 0.638264531879943
+            0.547, 0.98
         ],
         "cpk_interval": [
-            0.11952337094481465, 0.5170777274296965
-        ]
+            0.12, 0.52
+        ],
+        "error": null
     },
     "file432": {
         "data": [
@@ -7239,14 +7783,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 43.0,
         "lower_specification": null,
-        "cp_point": 0.4435136352882344,
-        "cpk_point": 0.15461781362067314,
+        "cp_point": 0.681,
+        "cpk_point": 0.155,
         "cp_interval": [
-            0.25939500690954914, 0.5628446036004314
+            0.398, 0.864
         ],
         "cpk_interval": [
-            -0.06075972746771096, 0.41209475181578253
-        ]
+            -0.061, 0.457
+        ],
+        "error": null
     },
     "file433": {
         "data": [
@@ -7256,14 +7801,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 50.0,
         "lower_specification": null,
-        "cp_point": 1.1439666057390439,
-        "cpk_point": 0.6322353892813132,
+        "cp_point": 1.787,
+        "cpk_point": 1.504,
         "cp_interval": [
-            0.6357259222386057, 1.38469140932745
+            0.993, 2.164
         ],
         "cpk_interval": [
-            0.36991724591531855, 0.904446128473627
-        ]
+            0.603, 1.96
+        ],
+        "error": null
     },
     "file434": {
         "data": [
@@ -7273,14 +7819,15 @@
         "lower_extreme": null,
         "upper_specification": 37.7,
         "lower_specification": 37.6,
-        "cp_point": 1.0597342070101885,
-        "cpk_point": -0.5669682149187277,
+        "cp_point": 1.06,
+        "cpk_point": -0.567,
         "cp_interval": [
-            0.3959806817967907, 1.3512136933482164
+            0.396, 1.351
         ],
         "cpk_interval": [
-            -1.0685554796283205, -0.17025766776995627
-        ]
+            -1.069, -0.17
+        ],
+        "error": null
     },
     "file435": {
         "data": [
@@ -7290,14 +7837,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 20.0,
         "lower_specification": null,
-        "cp_point": 2.4469155157581346,
-        "cpk_point": 0.7865512172787259,
+        "cp_point": 2.719,
+        "cpk_point": 2.899,
         "cp_interval": [
-            0.667596940246052, 4.0507400163669125
+            0.742, 4.501
         ],
         "cpk_interval": [
-            0.45669974338395014, 0.9664424547027571
-        ]
+            0.676, 5.305
+        ],
+        "error": null
     },
     "file436": {
         "data": [
@@ -7307,14 +7855,15 @@
         "lower_extreme": null,
         "upper_specification": 39.52,
         "lower_specification": 39.47,
-        "cp_point": 1.3071579553939996,
-        "cpk_point": -0.14243979293565995,
+        "cp_point": 1.307,
+        "cpk_point": -0.142,
         "cp_interval": [
-            0.7764727273780683, 1.7369043844160597
+            0.776, 1.737
         ],
         "cpk_interval": [
-            -0.2865080060696451, 0.002378260272525962
-        ]
+            -0.287, 0.002
+        ],
+        "error": null
     },
     "file437": {
         "data": [
@@ -7324,14 +7873,15 @@
         "lower_extreme": null,
         "upper_specification": 31.7,
         "lower_specification": 31.6,
-        "cp_point": 0.8492890235872788,
-        "cpk_point": -2.121414875441568,
+        "cp_point": 0.849,
+        "cpk_point": -2.121,
         "cp_interval": [
-            0.4670741503999167, 1.1561916680970177
+            0.467, 1.156
         ],
         "cpk_interval": [
-            -3.0823493382284943, -1.0563953799511039
-        ]
+            -3.082, -1.056
+        ],
+        "error": null
     },
     "file438": {
         "data": [
@@ -7341,14 +7891,15 @@
         "lower_extreme": null,
         "upper_specification": 30.183,
         "lower_specification": 30.113,
-        "cp_point": 1.8704890675479895,
-        "cpk_point": 0.5799284769092893,
+        "cp_point": 1.87,
+        "cpk_point": 0.58,
         "cp_interval": [
-            0.8755368792330688, 2.695115017244889
+            0.876, 2.695
         ],
         "cpk_interval": [
-            0.3351024706009998, 0.8511897197044783
-        ]
+            0.335, 0.851
+        ],
+        "error": null
     },
     "file439": {
         "data": [
@@ -7358,14 +7909,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 10.0,
         "lower_specification": null,
-        "cp_point": 2.2517198263769993,
-        "cpk_point": 0.6528113374246017,
+        "cp_point": 2.815,
+        "cpk_point": 3.7,
         "cp_interval": [
-            1.3704840521642259, 2.9896633314375998
+            1.713, 3.737
         ],
         "cpk_interval": [
-            0.343012601300011, 0.934293438058249
-        ]
+            2.112, 4.993
+        ],
+        "error": null
     },
     "file440": {
         "data": [
@@ -7375,14 +7927,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 10.0,
         "lower_specification": null,
-        "cp_point": 3.0960241899331162,
-        "cpk_point": 0.6413854707693615,
+        "cp_point": 4.208,
+        "cpk_point": 4.476,
         "cp_interval": [
-            0.6920483290257232, 3.774071016259742
+            0.941, 5.13
         ],
         "cpk_interval": [
-            0.2746324485569672, 0.9264900067877716
-        ]
+            0.713, 7.384
+        ],
+        "error": null
     },
     "file441": {
         "data": [
@@ -7392,14 +7945,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 2.3161714534962248,
-        "cpk_point": 0.6376925496951148,
+        "cp_point": 3.025,
+        "cpk_point": 3.51,
         "cp_interval": [
-            1.2344428485669323, 3.042285167466453
+            1.612, 3.974
         ],
         "cpk_interval": [
-            0.29243684620994803, 0.9181974870005116
-        ]
+            1.507, 6.636
+        ],
+        "error": null
     },
     "file442": {
         "data": [
@@ -7409,14 +7963,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 0.7595171902206808,
-        "cpk_point": 0.7080790126424501,
+        "cp_point": 1.195,
+        "cpk_point": 0.767,
         "cp_interval": [
-            0.013872733454951637, 1.2914208025721898
+            0.022, 2.032
         ],
         "cpk_interval": [
-            0.012694799530769556, 0.9620831795936168
-        ]
+            0.013, 1.49
+        ],
+        "error": null
     },
     "file443": {
         "data": [
@@ -7426,14 +7981,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 20.0,
         "lower_specification": null,
-        "cp_point": 0.07174351736849083,
-        "cpk_point": -0.1222435687012656,
+        "cp_point": 0.239,
+        "cpk_point": -0.122,
         "cp_interval": [
-            0.02712559863596187, 0.1144643893804307
+            0.09, 0.382
         ],
         "cpk_interval": [
-            -0.23621786893092106, -0.012948215716442092
-        ]
+            -0.236, -0.013
+        ],
+        "error": null
     },
     "file444": {
         "data": [
@@ -7443,14 +7999,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 20.0,
         "lower_specification": null,
-        "cp_point": 0.13682171724895145,
-        "cpk_point": -0.20776560125517826,
+        "cp_point": 0.274,
+        "cpk_point": -0.208,
         "cp_interval": [
-            0.07766480128205587, 0.18959991707855206
+            0.155, 0.379
         ],
         "cpk_interval": [
-            -0.3659835472898229, -0.037725684052863
-        ]
+            -0.366, -0.038
+        ],
+        "error": null
     },
     "file445": {
         "data": [
@@ -7460,14 +8017,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 50.0,
         "lower_specification": null,
-        "cp_point": 0.791907882468993,
-        "cpk_point": 0.5805069857678374,
+        "cp_point": 1.07,
+        "cpk_point": 0.999,
         "cp_interval": [
-            0.533849765074554, 1.0372822581856274
+            0.721, 1.402
         ],
         "cpk_interval": [
-            0.3771859957276065, 0.8004498503215786
-        ]
+            0.553, 1.43
+        ],
+        "error": null
     },
     "file446": {
         "data": [
@@ -7477,14 +8035,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.0678453241052126,
-        "cpk_point": 0.7415898503836312,
+        "cp_point": 2.068,
+        "cpk_point": 0.742,
         "cp_interval": [
-            0.9166523134280423, 3.020907494781611
+            0.917, 3.021
         ],
         "cpk_interval": [
-            0.249747696136739, 1.1659262653456546
-        ]
+            0.25, 1.166
+        ],
+        "error": null
     },
     "file447": {
         "data": [
@@ -7494,14 +8053,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.7619986778769365,
-        "cpk_point": 0.8399786752150902,
+        "cp_point": 2.762,
+        "cpk_point": 0.84,
         "cp_interval": [
-            1.2582667460901598, 4.02150355590055
+            1.258, 4.022
         ],
         "cpk_interval": [
-            0.30924397082701194, 1.29290458711033
-        ]
+            0.309, 1.293
+        ],
+        "error": null
     },
     "file448": {
         "data": [
@@ -7511,14 +8071,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.902787131437062,
-        "cpk_point": 0.8239633673731993,
+        "cp_point": 2.903,
+        "cpk_point": 0.824,
         "cp_interval": [
-            1.327056171330635, 4.224729870852339
+            1.327, 4.225
         ],
         "cpk_interval": [
-            0.3041009800301926, 1.2669882357346125
-        ]
+            0.304, 1.267
+        ],
+        "error": null
     },
     "file449": {
         "data": [
@@ -7528,14 +8089,15 @@
         "lower_extreme": null,
         "upper_specification": 12.0,
         "lower_specification": 4.0,
-        "cp_point": 1.0801343109323467,
-        "cpk_point": 0.5608303626462973,
+        "cp_point": 1.08,
+        "cpk_point": 0.561,
         "cp_interval": [
-            0.27835575518737526, 1.2970556532325286
+            0.278, 1.297
         ],
         "cpk_interval": [
-            0.12736469410211004, 0.7032015618517232
-        ]
+            0.127, 0.703
+        ],
+        "error": null
     },
     "file450": {
         "data": [
@@ -7545,14 +8107,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 1.942338178460097,
-        "cpk_point": 0.731485305895708,
+        "cp_point": 1.942,
+        "cpk_point": 0.731,
         "cp_interval": [
-            0.8527561723356196, 2.840859095168981
+            0.853, 2.841
         ],
         "cpk_interval": [
-            0.24199915708734984, 1.1570046215921979
-        ]
+            0.242, 1.157
+        ],
+        "error": null
     },
     "file451": {
         "data": [
@@ -7562,14 +8125,15 @@
         "lower_extreme": null,
         "upper_specification": 20.0,
         "lower_specification": 10.0,
-        "cp_point": 2.4017713033582253,
-        "cpk_point": 1.5564088627026342,
+        "cp_point": 2.402,
+        "cpk_point": 1.556,
         "cp_interval": [
-            0.0031822771771379942, 3.88921849838172
+            0.003, 3.889
         ],
         "cpk_interval": [
-            0.0015783889669346261, 3.4261854261202878
-        ]
+            0.002, 3.426
+        ],
+        "error": null
     },
     "file452": {
         "data": [
@@ -7579,14 +8143,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 2.278943636533749,
-        "cpk_point": 2.2571046796151806,
+        "cp_point": 2.279,
+        "cpk_point": 2.257,
         "cp_interval": [
-            1.421462805136318, 3.0254238213885416
+            1.421, 3.025
         ],
         "cpk_interval": [
-            1.258618594745959, 2.876178318454419
-        ]
+            1.259, 2.876
+        ],
+        "error": null
     },
     "file453": {
         "data": [
@@ -7596,14 +8161,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": 1.0,
-        "cp_point": 1.3079248843177602,
-        "cpk_point": 0.9218124409159587,
+        "cp_point": 1.308,
+        "cpk_point": 0.922,
         "cp_interval": [
-            0.8146414932345443, 1.7564711584939214
+            0.815, 1.756
         ],
         "cpk_interval": [
-            0.49791766616289446, 1.355462184237923
-        ]
+            0.498, 1.355
+        ],
+        "error": null
     },
     "file454": {
         "data": [
@@ -7613,14 +8179,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 2.486489693040931,
-        "cpk_point": 2.1580955951274223,
+        "cp_point": 2.486,
+        "cpk_point": 2.158,
         "cp_interval": [
-            1.6664051158863156, 3.231058115394599
+            1.666, 3.231
         ],
         "cpk_interval": [
-            1.4831733481246605, 2.787138960090851
-        ]
+            1.483, 2.787
+        ],
+        "error": null
     },
     "file455": {
         "data": [
@@ -7629,7 +8196,16 @@
         "upper_extreme": null,
         "lower_extreme": null,
         "upper_specification": 5.0,
-        "lower_specification": 1.0
+        "lower_specification": 1.0,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More unique values are required to calculate capability indexes."
     },
     "file456": {
         "data": [
@@ -7639,14 +8215,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 1.75507305108159,
-        "cpk_point": 1.290072205678453,
+        "cp_point": 1.755,
+        "cpk_point": 1.29,
         "cp_interval": [
-            1.1830901013798838, 2.27608341162241
+            1.183, 2.276
         ],
         "cpk_interval": [
-            0.8434991029266258, 1.725427508792936
-        ]
+            0.843, 1.725
+        ],
+        "error": null
     },
     "file457": {
         "data": [
@@ -7656,14 +8233,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 1.7368599416836819,
-        "cpk_point": 1.2727242146167541,
+        "cp_point": 1.737,
+        "cpk_point": 1.273,
         "cp_interval": [
-            1.1202059104488478, 2.302778849953903
+            1.12, 2.303
         ],
         "cpk_interval": [
-            0.7319007918356649, 1.8371352411562116
-        ]
+            0.732, 1.837
+        ],
+        "error": null
     },
     "file458": {
         "data": [
@@ -7673,14 +8251,15 @@
         "lower_extreme": null,
         "upper_specification": 18.0,
         "lower_specification": 12.0,
-        "cp_point": 2.428794239127576,
-        "cpk_point": 1.9992112315752344,
+        "cp_point": 2.429,
+        "cpk_point": 1.999,
         "cp_interval": [
-            1.5898222807840385, 3.196586975341318
+            1.59, 3.197
         ],
         "cpk_interval": [
-            1.23263892217483, 2.7582441980345775
-        ]
+            1.233, 2.758
+        ],
+        "error": null
     },
     "file459": {
         "data": [
@@ -7690,14 +8269,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 2.4227363647219105,
-        "cpk_point": 0.787300745234434,
+        "cp_point": 2.534,
+        "cpk_point": 3.008,
         "cp_interval": [
-            1.4767908953171112, 3.391491968875786
+            1.544, 3.547
         ],
         "cpk_interval": [
-            0.5677358322340477, 0.9165225229786131
-        ]
+            1.669, 4.47
+        ],
+        "error": null
     },
     "file460": {
         "data": [
@@ -7707,14 +8287,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 3.527140559943499,
-        "cpk_point": 0.7734965140701857,
+        "cp_point": 3.68,
+        "cpk_point": 4.927,
         "cp_interval": [
-            2.4239629550862056, 4.602048928292708
+            2.529, 4.802
         ],
         "cpk_interval": [
-            0.5512125180309176, 0.9180696916292725
-        ]
+            3.055, 6.702
+        ],
+        "error": null
     },
     "file461": {
         "data": [
@@ -7724,14 +8305,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 1.86612035159818,
-        "cpk_point": 0.718712852659738,
+        "cp_point": 2.133,
+        "cpk_point": 2.573,
         "cp_interval": [
-            1.2723490837535407, 2.273673979420323
+            1.454, 2.598
         ],
         "cpk_interval": [
-            0.5310310510444898, 0.8900240689437938
-        ]
+            1.554, 3.93
+        ],
+        "error": null
     },
     "file462": {
         "data": [
@@ -7741,14 +8323,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.2663545883498446,
-        "cpk_point": 1.2599069827352625,
+        "cp_point": 2.266,
+        "cpk_point": 1.26,
         "cp_interval": [
-            1.1312439354421016, 3.1317652622945733
+            1.131, 3.132
         ],
         "cpk_interval": [
-            0.8171844975070452, 1.6887952807240942
-        ]
+            0.817, 1.689
+        ],
+        "error": null
     },
     "file463": {
         "data": [
@@ -7758,14 +8341,15 @@
         "lower_extreme": null,
         "upper_specification": 42.2,
         "lower_specification": 41.95,
-        "cp_point": 2.7808073812120395,
-        "cpk_point": 1.3333881017084712,
+        "cp_point": 2.781,
+        "cpk_point": 1.333,
         "cp_interval": [
-            1.7823989403661344, 3.652421042751148
+            1.782, 3.652
         ],
         "cpk_interval": [
-            0.9217359312597222, 1.7123035349209883
-        ]
+            0.922, 1.712
+        ],
+        "error": null
     },
     "file464": {
         "data": [
@@ -7775,14 +8359,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.5425888964603436,
-        "cpk_point": 1.2902044226970413,
+        "cp_point": 2.543,
+        "cpk_point": 1.29,
         "cp_interval": [
-            1.5123508880963465, 3.394973775495669
+            1.512, 3.395
         ],
         "cpk_interval": [
-            0.7777905705991756, 1.7969184321811063
-        ]
+            0.778, 1.797
+        ],
+        "error": null
     },
     "file465": {
         "data": [
@@ -7792,14 +8377,15 @@
         "lower_extreme": null,
         "upper_specification": 51.8,
         "lower_specification": 51.65,
-        "cp_point": 2.1777087500858463,
-        "cpk_point": 2.0211240141703017,
+        "cp_point": 2.178,
+        "cpk_point": 2.021,
         "cp_interval": [
-            1.402767208808144, 2.8888951575606825
+            1.403, 2.889
         ],
         "cpk_interval": [
-            1.2105457349322495, 2.7829824283083457
-        ]
+            1.211, 2.783
+        ],
+        "error": null
     },
     "file466": {
         "data": [
@@ -7809,14 +8395,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.778532499227391,
-        "cpk_point": 1.295009558722156,
+        "cp_point": 2.779,
+        "cpk_point": 1.295,
         "cp_interval": [
-            1.6508790202433892, 3.732196066548045
+            1.651, 3.732
         ],
         "cpk_interval": [
-            0.7455370482242322, 1.836962510968396
-        ]
+            0.746, 1.837
+        ],
+        "error": null
     },
     "file467": {
         "data": [
@@ -7826,14 +8413,15 @@
         "lower_extreme": null,
         "upper_specification": 50.876,
         "lower_specification": 50.819,
-        "cp_point": 2.0043331248820313,
-        "cpk_point": 0.9967175276094663,
+        "cp_point": 2.004,
+        "cpk_point": 0.997,
         "cp_interval": [
-            1.4168450076613754, 2.4711982344926753
+            1.417, 2.471
         ],
         "cpk_interval": [
-            0.6149924145934905, 1.3685852176962563
-        ]
+            0.615, 1.369
+        ],
+        "error": null
     },
     "file468": {
         "data": [
@@ -7843,14 +8431,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.615847976249368,
-        "cpk_point": 0.9524916755127328,
+        "cp_point": 2.616,
+        "cpk_point": 0.952,
         "cp_interval": [
-            1.5351274270669573, 3.534976579841148
+            1.535, 3.535
         ],
         "cpk_interval": [
-            0.5299468051082636, 1.3564500886019735
-        ]
+            0.53, 1.356
+        ],
+        "error": null
     },
     "file469": {
         "data": [
@@ -7860,14 +8449,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.8904911411820766,
-        "cpk_point": 1.4427824821057673,
+        "cp_point": 2.89,
+        "cpk_point": 1.443,
         "cp_interval": [
-            1.9238790639034005, 3.761739377691259
+            1.924, 3.762
         ],
         "cpk_interval": [
-            0.9817663532818746, 1.8719490747848322
-        ]
+            0.982, 1.872
+        ],
+        "error": null
     },
     "file470": {
         "data": [
@@ -7877,14 +8467,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.6418564401407574,
-        "cpk_point": 1.4325070998643679,
+        "cp_point": 2.642,
+        "cpk_point": 1.433,
         "cp_interval": [
-            1.6755152883042956, 3.4777087815432592
+            1.676, 3.478
         ],
         "cpk_interval": [
-            1.001717926334381, 1.823604383835892
-        ]
+            1.002, 1.824
+        ],
+        "error": null
     },
     "file471": {
         "data": [
@@ -7894,14 +8485,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 2.9903055818219855,
-        "cpk_point": 2.1865387889556853,
+        "cp_point": 2.99,
+        "cpk_point": 2.187,
         "cp_interval": [
-            1.9883436245922452, 3.8986247395446716
+            1.988, 3.899
         ],
         "cpk_interval": [
-            1.391851228464715, 2.94518236275939
-        ]
+            1.392, 2.945
+        ],
+        "error": null
     },
     "file472": {
         "data": [
@@ -7911,14 +8503,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 1.9736473829388232,
-        "cpk_point": 1.1496813628472768,
+        "cp_point": 1.974,
+        "cpk_point": 1.15,
         "cp_interval": [
-            1.1173521827005206, 2.446708324588371
+            1.117, 2.447
         ],
         "cpk_interval": [
-            0.5749544497348623, 1.5488717065209665
-        ]
+            0.575, 1.549
+        ],
+        "error": null
     },
     "file473": {
         "data": [
@@ -7928,14 +8521,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.15388460186983288,
-        "cpk_point": -0.014584379908169758,
+        "cp_point": 1.055,
+        "cpk_point": -0.015,
         "cp_interval": [
-            0.08242708352892068, 0.22931183780107406
+            0.565, 1.572
         ],
         "cpk_interval": [
-            -0.07343799048650633, 0.05873970500270887
-        ]
+            -0.073, 0.059
+        ],
+        "error": null
     },
     "file474": {
         "data": [
@@ -7945,14 +8539,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 1.0554678217612847,
-        "cpk_point": 0.7095916424898652,
+        "cp_point": 1.297,
+        "cpk_point": 1.184,
         "cp_interval": [
-            0.6041330323843639, 1.5182034075550266
+            0.742, 1.866
         ],
         "cpk_interval": [
-            0.4427730402405119, 0.8649877218408618
-        ]
+            0.577, 1.843
+        ],
+        "error": null
     },
     "file475": {
         "data": [
@@ -7961,7 +8556,16 @@
         "upper_extreme": null,
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
-        "lower_specification": null
+        "lower_specification": null,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More unique values are required to calculate capability indexes."
     },
     "file476": {
         "data": [
@@ -7971,14 +8575,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.0382278973999395,
-        "cpk_point": 0.6674043576015953,
+        "cp_point": 1.51,
+        "cpk_point": 1.142,
         "cp_interval": [
-            0.36672627569349403, 1.7283672922841302
+            0.533, 2.514
         ],
         "cpk_interval": [
-            0.3265809286878038, 0.8361395034772585
-        ]
+            0.331, 2.097
+        ],
+        "error": null
     },
     "file477": {
         "data": [
@@ -7988,14 +8593,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.7754016357395783,
-        "cpk_point": 0.8595492819748382,
+        "cp_point": 1.869,
+        "cpk_point": 2.245,
         "cp_interval": [
-            1.206509088657112, 2.3298796887023374
+            1.27, 2.453
         ],
         "cpk_interval": [
-            0.687127124078922, 0.9948852214326364
-        ]
+            1.361, 3.137
+        ],
+        "error": null
     },
     "file478": {
         "data": [
@@ -8005,14 +8611,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.8549111620467813,
-        "cpk_point": 0.9182080554386556,
+        "cp_point": 1.902,
+        "cpk_point": 2.226,
         "cp_interval": [
-            1.1741741250411517, 2.5395243428297913
+            1.204, 2.605
         ],
         "cpk_interval": [
-            0.7876696819668348, 1.0371877763084525
-        ]
+            1.259, 3.26
+        ],
+        "error": null
     },
     "file479": {
         "data": [
@@ -8022,14 +8629,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 20.0,
         "lower_specification": null,
-        "cp_point": 0.06115099107976868,
-        "cpk_point": -0.1971573748478303,
+        "cp_point": 0.245,
+        "cpk_point": -0.197,
         "cp_interval": [
-            0.01937095196934806, 0.09548144959866174
+            0.077, 0.382
         ],
         "cpk_interval": [
-            -0.43838202840014945, 0.010841947002275736
-        ]
+            -0.438, 0.011
+        ],
+        "error": null
     },
     "file480": {
         "data": [
@@ -8039,14 +8647,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 20.0,
         "lower_specification": null,
-        "cp_point": 0.13764947552725,
-        "cpk_point": -0.3658486356319957,
+        "cp_point": 0.344,
+        "cpk_point": -0.366,
         "cp_interval": [
-            0.049469551194095907, 0.17871371520442372
+            0.124, 0.447
         ],
         "cpk_interval": [
-            -0.7254653501309715, 0.02544446277787463
-        ]
+            -0.725, 0.067
+        ],
+        "error": null
     },
     "file481": {
         "data": [
@@ -8056,14 +8665,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 50.0,
         "lower_specification": null,
-        "cp_point": 0.5387255025068526,
-        "cpk_point": 0.5134016783682537,
+        "cp_point": 0.748,
+        "cpk_point": 0.513,
         "cp_interval": [
-            0.2458077276216368, 0.8023787688446143
+            0.341, 1.114
         ],
         "cpk_interval": [
-            0.19106449763899686, 0.6948140779114987
-        ]
+            0.191, 0.9
+        ],
+        "error": null
     },
     "file482": {
         "data": [
@@ -8073,14 +8683,15 @@
         "lower_extreme": null,
         "upper_specification": 31.7,
         "lower_specification": 31.6,
-        "cp_point": 0.47630695653576305,
-        "cpk_point": -5.19412021989467,
+        "cp_point": 0.476,
+        "cpk_point": -5.194,
         "cp_interval": [
-            0.26329442006707315, 0.6413674742297347
+            0.263, 0.641
         ],
         "cpk_interval": [
-            -7.303601261453205, -2.697080425901578
-        ]
+            -7.304, -2.697
+        ],
+        "error": null
     },
     "file483": {
         "data": [
@@ -8090,14 +8701,15 @@
         "lower_extreme": null,
         "upper_specification": 30.183,
         "lower_specification": 30.113,
-        "cp_point": 3.615901419673811,
-        "cpk_point": 0.10252767474273977,
+        "cp_point": 3.616,
+        "cpk_point": 0.103,
         "cp_interval": [
-            1.9448813830146512, 5.0808948637297
+            1.945, 5.081
         ],
         "cpk_interval": [
-            -0.08354272054056205, 0.31353966769520963
-        ]
+            -0.084, 0.314
+        ],
+        "error": null
     },
     "file484": {
         "data": [
@@ -8107,14 +8719,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 10.0,
         "lower_specification": null,
-        "cp_point": 1.5917499120503782,
-        "cpk_point": 0.5656267787605701,
+        "cp_point": 2.547,
+        "cpk_point": 2.444,
         "cp_interval": [
-            0.9164763315945911, 2.128126199169233
+            1.466, 3.405
         ],
         "cpk_interval": [
-            0.26421910452511427, 0.8249061729823512
-        ]
+            1.336, 3.433
+        ],
+        "error": null
     },
     "file485": {
         "data": [
@@ -8124,14 +8737,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 10.0,
         "lower_specification": null,
-        "cp_point": 1.387835206411521,
-        "cpk_point": 0.5508539074482639,
+        "cp_point": 2.221,
+        "cpk_point": 2.069,
         "cp_interval": [
-            0.8030173167601348, 1.8569639310651649
+            1.285, 2.971
         ],
         "cpk_interval": [
-            0.2560029431637406, 0.808540028483162
-        ]
+            1.121, 2.932
+        ],
+        "error": null
     },
     "file486": {
         "data": [
@@ -8141,14 +8755,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 2.172773737994107,
-        "cpk_point": 0.9707797614250149,
+        "cp_point": 2.248,
+        "cpk_point": 2.792,
         "cp_interval": [
-            1.5584185197428975, 2.74206762524051
+            1.612, 2.837
         ],
         "cpk_interval": [
-            0.8422928546164379, 1.0826482647967755
-        ]
+            1.824, 3.714
+        ],
+        "error": null
     },
     "file487": {
         "data": [
@@ -8158,14 +8773,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.756029872966269,
-        "cpk_point": 0.7288271311609269,
+        "cp_point": 0.775,
+        "cpk_point": 0.729,
         "cp_interval": [
-            0.0050124204958184055, 1.6200820706381431
+            0.005, 1.662
         ],
         "cpk_interval": [
-            0.004159077673522581, 0.9734865967581647
-        ]
+            0.004, 1.819
+        ],
+        "error": null
     },
     "file488": {
         "data": [
@@ -8175,14 +8791,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 2.3752529423473563,
-        "cpk_point": 0.9193373216538211,
+        "cp_point": 2.375,
+        "cpk_point": 0.919,
         "cp_interval": [
-            1.6874816793512162, 2.9616411300790233
+            1.687, 2.962
         ],
         "cpk_interval": [
-            0.605500182964028, 1.153422940659411
-        ]
+            0.606, 1.153
+        ],
+        "error": null
     },
     "file489": {
         "data": [
@@ -8192,14 +8809,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 2.19572542066057,
-        "cpk_point": 0.37611865981440706,
+        "cp_point": 2.196,
+        "cpk_point": 0.376,
         "cp_interval": [
-            1.5195014548227597, 2.756998391105798
+            1.52, 2.757
         ],
         "cpk_interval": [
-            0.23667747605289002, 0.5502441848681703
-        ]
+            0.237, 0.55
+        ],
+        "error": null
     },
     "file490": {
         "data": [
@@ -8209,14 +8827,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 2.207319066885035,
-        "cpk_point": 0.7217134138264621,
+        "cp_point": 2.207,
+        "cpk_point": 0.722,
         "cp_interval": [
-            1.5820648737552263, 2.745360498438377
+            1.582, 2.745
         ],
         "cpk_interval": [
-            0.4750644029300524, 0.9139054807138366
-        ]
+            0.475, 0.914
+        ],
+        "error": null
     },
     "file491": {
         "data": [
@@ -8226,14 +8845,15 @@
         "lower_extreme": null,
         "upper_specification": 10.0,
         "lower_specification": 2.0,
-        "cp_point": 1.6772792906652862,
-        "cpk_point": 0.22620233336444664,
+        "cp_point": 1.677,
+        "cpk_point": 0.226,
         "cp_interval": [
-            1.2251018051383435, 2.090749097752332
+            1.225, 2.091
         ],
         "cpk_interval": [
-            0.1111463482124831, 0.3691683330962032
-        ]
+            0.111, 0.369
+        ],
+        "error": null
     },
     "file492": {
         "data": [
@@ -8243,14 +8863,15 @@
         "lower_extreme": null,
         "upper_specification": 17.0,
         "lower_specification": 9.0,
-        "cp_point": 1.9231148099074273,
-        "cpk_point": 0.7923742728083181,
+        "cp_point": 1.923,
+        "cpk_point": 0.792,
         "cp_interval": [
-            1.376729659409191, 2.3903049412394384
+            1.377, 2.39
         ],
         "cpk_interval": [
-            0.5217011546266728, 0.9940400769222484
-        ]
+            0.522, 0.994
+        ],
+        "error": null
     },
     "file493": {
         "data": [
@@ -8260,14 +8881,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 2.682142478176173,
-        "cpk_point": -1.2683261145879887,
+        "cp_point": 2.682,
+        "cpk_point": -1.268,
         "cp_interval": [
-            1.9413899669598258, 3.367572300632022
+            1.941, 3.368
         ],
         "cpk_interval": [
-            -1.6132061160341091, -0.8747720852241683
-        ]
+            -1.613, -0.875
+        ],
+        "error": null
     },
     "file494": {
         "data": [
@@ -8277,14 +8899,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 3.0,
-        "cp_point": 1.5349349461356678,
-        "cpk_point": 0.277870856144777,
+        "cp_point": 1.535,
+        "cpk_point": 0.278,
         "cp_interval": [
-            1.1017147481795724, 1.795060449826429
+            1.102, 1.795
         ],
         "cpk_interval": [
-            0.12989534798350932, 0.5006662974160349
-        ]
+            0.13, 0.501
+        ],
+        "error": null
     },
     "file495": {
         "data": [
@@ -8294,14 +8917,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 3.0,
-        "cp_point": 1.5295498041715636,
-        "cpk_point": 1.1193898215987377,
+        "cp_point": 1.53,
+        "cpk_point": 1.119,
         "cp_interval": [
-            1.0708316153045445, 1.7448467981413847
+            1.071, 1.745
         ],
         "cpk_interval": [
-            0.6460880303314154, 1.3330165050121048
-        ]
+            0.646, 1.333
+        ],
+        "error": null
     },
     "file496": {
         "data": [
@@ -8311,14 +8935,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": 2.0,
-        "cp_point": 2.976643213540318,
-        "cpk_point": 1.138919809355949,
+        "cp_point": 2.977,
+        "cpk_point": 1.139,
         "cp_interval": [
-            2.1152044889811235, 3.7561703560493687
+            2.115, 3.756
         ],
         "cpk_interval": [
-            0.839795949744204, 1.3791653015769396
-        ]
+            0.84, 1.379
+        ],
+        "error": null
     },
     "file497": {
         "data": [
@@ -8328,14 +8953,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": 2.0,
-        "cp_point": 2.2794029441993384,
-        "cpk_point": 1.80943360872905,
+        "cp_point": 2.279,
+        "cpk_point": 1.809,
         "cp_interval": [
-            1.751934834333259, 2.646079323843933
+            1.752, 2.646
         ],
         "cpk_interval": [
-            1.1921604258624845, 2.4123480707043994
-        ]
+            1.192, 2.412
+        ],
+        "error": null
     },
     "file498": {
         "data": [
@@ -8345,14 +8971,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 5.983642957542823,
-        "cpk_point": 0.847170182939775,
+        "cp_point": 6.221,
+        "cpk_point": 11.909,
         "cp_interval": [
-            4.580217407237642, 6.99802376350901
+            4.762, 7.276
         ],
         "cpk_interval": [
-            0.6888210850050976, 0.9809903648092936
-        ]
+            6.819, 16.29
+        ],
+        "error": null
     },
     "file499": {
         "data": [
@@ -8362,14 +8989,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 2.129115478403861,
-        "cpk_point": 0.8119708422498421,
+        "cp_point": 2.212,
+        "cpk_point": 2.461,
         "cp_interval": [
-            0.8442142251218395, 3.939650128971557
+            0.877, 4.093
         ],
         "cpk_interval": [
-            0.6548311883573247, 0.9258957424049352
-        ]
+            0.853, 5.435
+        ],
+        "error": null
     },
     "file500": {
         "data": [
@@ -8379,14 +9007,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 1.9343690345836424,
-        "cpk_point": 0.6400430432923062,
+        "cp_point": 2.083,
+        "cpk_point": 2.136,
         "cp_interval": [
-            0.5122435293803218, 3.593202786558305
+            0.552, 3.869
         ],
         "cpk_interval": [
-            0.43367748337759426, 0.7622558415282201
-        ]
+            0.511, 4.364
+        ],
+        "error": null
     },
     "file501": {
         "data": [
@@ -8396,14 +9025,15 @@
         "lower_extreme": null,
         "upper_specification": 65.49,
         "lower_specification": 65.22,
-        "cp_point": 2.0759845218491435,
-        "cpk_point": 1.6577914539107703,
+        "cp_point": 2.076,
+        "cpk_point": 1.658,
         "cp_interval": [
-            1.4768438517228497, 2.6234358933827178
+            1.477, 2.623
         ],
         "cpk_interval": [
-            1.127565953515636, 2.173409106688643
-        ]
+            1.128, 2.173
+        ],
+        "error": null
     },
     "file502": {
         "data": [
@@ -8413,14 +9043,15 @@
         "lower_extreme": null,
         "upper_specification": 78.2,
         "lower_specification": 78.05,
-        "cp_point": 2.405617079684917,
-        "cpk_point": 2.28015040550198,
+        "cp_point": 2.406,
+        "cpk_point": 2.28,
         "cp_interval": [
-            1.8639712617686321, 2.833121854747217
+            1.864, 2.833
         ],
         "cpk_interval": [
-            1.5765436579574257, 2.708151115440013
-        ]
+            1.577, 2.708
+        ],
+        "error": null
     },
     "file503": {
         "data": [
@@ -8430,14 +9061,15 @@
         "lower_extreme": null,
         "upper_specification": 77.046,
         "lower_specification": 76.985,
-        "cp_point": 1.0419194823919324,
-        "cpk_point": 0.4625439679449483,
+        "cp_point": 1.042,
+        "cpk_point": 0.463,
         "cp_interval": [
-            0.7404056109345544, 1.2996871760878344
+            0.74, 1.3
         ],
         "cpk_interval": [
-            0.28006490364563735, 0.6135662501678915
-        ]
+            0.28, 0.614
+        ],
+        "error": null
     },
     "file504": {
         "data": [
@@ -8447,14 +9079,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": -5.0,
-        "cp_point": 1.7015878066740677,
-        "cpk_point": 1.1661910822510306,
+        "cp_point": 1.702,
+        "cpk_point": 1.166,
         "cp_interval": [
-            1.1995591911313888, 2.128791040930694
+            1.2, 2.129
         ],
         "cpk_interval": [
-            0.8834985000001904, 1.4431118384256525
-        ]
+            0.883, 1.443
+        ],
+        "error": null
     },
     "file505": {
         "data": [
@@ -8464,14 +9097,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": -5.0,
-        "cp_point": 1.6290136077079325,
-        "cpk_point": 0.8719719831661891,
+        "cp_point": 1.629,
+        "cpk_point": 0.872,
         "cp_interval": [
-            1.1764463990211418, 2.0298093230265617
+            1.176, 2.03
         ],
         "cpk_interval": [
-            0.5954569606391092, 1.1768045466099581
-        ]
+            0.595, 1.177
+        ],
+        "error": null
     },
     "file506": {
         "data": [
@@ -8481,14 +9115,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 1.975257773738066,
-        "cpk_point": 1.6661598141087344,
+        "cp_point": 1.975,
+        "cpk_point": 1.666,
         "cp_interval": [
-            1.3485243816691552, 2.511570313544956
+            1.349, 2.512
         ],
         "cpk_interval": [
-            1.0636857485307565, 2.157526687891015
-        ]
+            1.064, 2.158
+        ],
+        "error": null
     },
     "file507": {
         "data": [
@@ -8498,14 +9133,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 1.6968105116408276,
-        "cpk_point": 1.235832868250744,
+        "cp_point": 1.697,
+        "cpk_point": 1.236,
         "cp_interval": [
-            1.1273033893185411, 2.3802373471675886
+            1.127, 2.38
         ],
         "cpk_interval": [
-            0.822828664983865, 1.7891423566875746
-        ]
+            0.823, 1.789
+        ],
+        "error": null
     },
     "file508": {
         "data": [
@@ -8515,14 +9151,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.21776120628718373,
-        "cpk_point": 0.006989397299934541,
+        "cp_point": 1.415,
+        "cpk_point": 0.007,
         "cp_interval": [
-            0.14753290667191016, 0.28317862197470184
+            0.959, 1.841
         ],
         "cpk_interval": [
-            -0.06503652964901031, 0.09319317484139959
-        ]
+            -0.065, 0.093
+        ],
+        "error": null
     },
     "file509": {
         "data": [
@@ -8532,14 +9169,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.3790767597432769,
-        "cpk_point": 0.17389775554278558,
+        "cp_point": 0.807,
+        "cpk_point": 0.174,
         "cp_interval": [
-            0.2792906950259035, 0.4730122683809424
+            0.595, 1.007
         ],
         "cpk_interval": [
-            0.07064983574952605, 0.31138044051117697
-        ]
+            0.071, 0.311
+        ],
+        "error": null
     },
     "file510": {
         "data": [
@@ -8549,14 +9187,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.699847337846228,
-        "cpk_point": 0.732925032559172,
+        "cp_point": 1.907,
+        "cpk_point": 2.015,
         "cp_interval": [
-            1.0235007345047873, 2.369832985979842
+            1.148, 2.659
         ],
         "cpk_interval": [
-            0.5619587462270599, 0.8497252414672373
-        ]
+            1.108, 3.016
+        ],
+        "error": null
     },
     "file511": {
         "data": [
@@ -8566,14 +9205,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.4074612692429787,
-        "cpk_point": 0.6698456179679362,
+        "cp_point": 1.609,
+        "cpk_point": 1.593,
         "cp_interval": [
-            0.3095537074378966, 2.550139276919748
+            0.354, 2.914
         ],
         "cpk_interval": [
-            0.25518120020861207, 0.8911785759703804
-        ]
+            0.298, 3.241
+        ],
+        "error": null
     },
     "file512": {
         "data": [
@@ -8583,14 +9223,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.9645590572148133,
-        "cpk_point": 0.7669617774340147,
+        "cp_point": 2.456,
+        "cpk_point": 3.844,
         "cp_interval": [
-            0.09476948181653273, 2.447872576328795
+            0.118, 3.06
         ],
         "cpk_interval": [
-            0.07432928815755535, 0.9305855129892472
-        ]
+            0.074, 5.461
+        ],
+        "error": null
     },
     "file513": {
         "data": [
@@ -8600,14 +9241,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.903355128271062,
-        "cpk_point": 0.7436233546621364,
+        "cp_point": 2.213,
+        "cpk_point": 2.971,
         "cp_interval": [
-            1.0013993860148045, 2.425439701480754
+            1.164, 2.82
         ],
         "cpk_interval": [
-            0.38593602881707484, 0.9889891710526835
-        ]
+            1.271, 5.766
+        ],
+        "error": null
     },
     "file514": {
         "data": [
@@ -8617,14 +9259,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 2.7355067976751632,
-        "cpk_point": 0.852276173029476,
+        "cp_point": 2.879,
+        "cpk_point": 4.376,
         "cp_interval": [
-            0.00715429048412232, 3.4332841521482353
+            0.008, 3.614
         ],
         "cpk_interval": [
-            0.005737052532848777, 0.9496941017400692
-        ]
+            0.006, 6.545
+        ],
+        "error": null
     },
     "file515": {
         "data": [
@@ -8634,14 +9277,15 @@
         "lower_extreme": null,
         "upper_specification": 12.0,
         "lower_specification": 4.0,
-        "cp_point": 1.8560650920191633,
-        "cpk_point": 0.8991397032476551,
+        "cp_point": 1.856,
+        "cpk_point": 0.899,
         "cp_interval": [
-            0.9441276033395937, 2.6114597341198094
+            0.944, 2.611
         ],
         "cpk_interval": [
-            0.41753698679508605, 1.4045965482478273
-        ]
+            0.418, 1.405
+        ],
+        "error": null
     },
     "file516": {
         "data": [
@@ -8651,14 +9295,15 @@
         "lower_extreme": null,
         "upper_specification": 20.0,
         "lower_specification": 10.0,
-        "cp_point": 2.9933635576182778,
-        "cpk_point": 2.992964884906727,
+        "cp_point": 2.993,
+        "cpk_point": 2.993,
         "cp_interval": [
-            1.5764348347302082, 4.171468225902488
+            1.576, 4.171
         ],
         "cpk_interval": [
-            1.4714328510322219, 4.033212145484345
-        ]
+            1.471, 4.033
+        ],
+        "error": null
     },
     "file517": {
         "data": [
@@ -8668,14 +9313,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": 1.0,
-        "cp_point": 1.7478147507444175,
-        "cpk_point": 1.3871676529942714,
+        "cp_point": 1.748,
+        "cpk_point": 1.387,
         "cp_interval": [
-            0.20442566807635149, 2.1745301025802095
+            0.204, 2.175
         ],
         "cpk_interval": [
-            0.166020737295481, 1.8326176186274952
-        ]
+            0.166, 1.833
+        ],
+        "error": null
     },
     "file518": {
         "data": [
@@ -8685,14 +9331,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 1.7571912946614956,
-        "cpk_point": 0.5493386495675365,
+        "cp_point": 1.757,
+        "cpk_point": 0.549,
         "cp_interval": [
-            0.9340979032681088, 2.407041989532126
+            0.934, 2.407
         ],
         "cpk_interval": [
-            0.2722491514288084, 0.8648109766190893
-        ]
+            0.272, 0.865
+        ],
+        "error": null
     },
     "file519": {
         "data": [
@@ -8702,14 +9349,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": 1.0,
-        "cp_point": 1.7478147507444175,
-        "cpk_point": 1.3871676529942714,
+        "cp_point": 1.748,
+        "cpk_point": 1.387,
         "cp_interval": [
-            0.20442566807635149, 2.1745301025802095
+            0.204, 2.175
         ],
         "cpk_interval": [
-            0.166020737295481, 1.8326176186274952
-        ]
+            0.166, 1.833
+        ],
+        "error": null
     },
     "file520": {
         "data": [
@@ -8719,14 +9367,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 3.2217838003587844,
-        "cpk_point": 1.1131227064384288,
+        "cp_point": 3.222,
+        "cpk_point": 1.113,
         "cp_interval": [
-            1.7516060799472524, 3.9109204967953293
+            1.752, 3.911
         ],
         "cpk_interval": [
-            0.6316291610233773, 1.6161258197094657
-        ]
+            0.632, 1.616
+        ],
+        "error": null
     },
     "file521": {
         "data": [
@@ -8735,7 +9384,16 @@
         "upper_extreme": null,
         "lower_extreme": null,
         "upper_specification": 7.0,
-        "lower_specification": 1.0
+        "lower_specification": 1.0,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More unique values are required to calculate capability indexes."
     },
     "file522": {
         "data": [
@@ -8745,14 +9403,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 1.1048486391051013,
-        "cpk_point": 1.1045613669941248,
+        "cp_point": 1.105,
+        "cpk_point": 1.105,
         "cp_interval": [
-            0.4625776587183373, 1.6785294046566428
+            0.463, 1.679
         ],
         "cpk_interval": [
-            0.399343928868187, 1.5008818898776313
-        ]
+            0.399, 1.501
+        ],
+        "error": null
     },
     "file523": {
         "data": [
@@ -8762,14 +9421,15 @@
         "lower_extreme": null,
         "upper_specification": 18.0,
         "lower_specification": 12.0,
-        "cp_point": 2.608216593304487,
-        "cpk_point": 1.3469404700213419,
+        "cp_point": 2.608,
+        "cpk_point": 1.347,
         "cp_interval": [
-            0.17870605114974675, 3.315567579694871
+            0.179, 3.316
         ],
         "cpk_interval": [
-            0.17081802238075727, 1.9715186973343655
-        ]
+            0.171, 1.972
+        ],
+        "error": null
     },
     "file524": {
         "data": [
@@ -8779,14 +9439,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 1.7885864438283718,
-        "cpk_point": 1.2397312184161504,
+        "cp_point": 1.789,
+        "cpk_point": 1.24,
         "cp_interval": [
-            0.4220403015856973, 2.187768641854434
+            0.422, 2.188
         ],
         "cpk_interval": [
-            0.3629850055283623, 1.7551744112950236
-        ]
+            0.363, 1.755
+        ],
+        "error": null
     },
     "file525": {
         "data": [
@@ -8796,14 +9457,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.80073012381715,
-        "cpk_point": 1.7570382846355208,
+        "cp_point": 2.801,
+        "cpk_point": 1.757,
         "cp_interval": [
-            1.31789513219142, 4.068769374975122
+            1.318, 4.069
         ],
         "cpk_interval": [
-            1.0245174018775964, 2.399999682729942
-        ]
+            1.025, 2.4
+        ],
+        "error": null
     },
     "file526": {
         "data": [
@@ -8813,14 +9475,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 2.396163460969478,
-        "cpk_point": 0.8137945583088088,
+        "cp_point": 2.706,
+        "cpk_point": 5.236,
         "cp_interval": [
-            1.6512669395238713, 2.813858832155103
+            1.865, 3.178
         ],
         "cpk_interval": [
-            0.3780084002819392, 0.9526989225055877
-        ]
+            2.127, 8.186
+        ],
+        "error": null
     },
     "file527": {
         "data": [
@@ -8830,14 +9493,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 2.043291170243362,
-        "cpk_point": 0.7119083051139341,
+        "cp_point": 2.18,
+        "cpk_point": 2.708,
         "cp_interval": [
-            1.1167300743695021, 2.8628564525616964
+            1.191, 3.054
         ],
         "cpk_interval": [
-            0.472071650940464, 0.904360549086018
-        ]
+            1.239, 4.101
+        ],
+        "error": null
     },
     "file528": {
         "data": [
@@ -8847,14 +9511,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 1.6328502359664094,
-        "cpk_point": 1.1671119742904597,
+        "cp_point": 1.633,
+        "cpk_point": 1.167,
         "cp_interval": [
-            0.6772994409013435, 2.4399152858393567
+            0.677, 2.44
         ],
         "cpk_interval": [
-            0.5574035358495133, 1.6104682443080245
-        ]
+            0.557, 1.61
+        ],
+        "error": null
     },
     "file529": {
         "data": [
@@ -8864,14 +9529,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 3.177827710621653,
-        "cpk_point": 2.1310289798444635,
+        "cp_point": 3.178,
+        "cpk_point": 2.131,
         "cp_interval": [
-            1.6518710459621906, 4.396004859494609
+            1.652, 4.396
         ],
         "cpk_interval": [
-            1.0402728360695417, 3.1530132283098404
-        ]
+            1.04, 3.153
+        ],
+        "error": null
     },
     "file530": {
         "data": [
@@ -8881,14 +9547,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 0.6694143648901641,
-        "cpk_point": 0.6660297196373774,
+        "cp_point": 0.92,
+        "cpk_point": 0.666,
         "cp_interval": [
-            0.010822652266246992, 1.5856305114830034
+            0.015, 2.18
         ],
         "cpk_interval": [
-            0.009334958724049503, 0.913577097923221
-        ]
+            0.009, 1.875
+        ],
+        "error": null
     },
     "file531": {
         "data": [
@@ -8898,14 +9565,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 1.833112602742123,
-        "cpk_point": 1.790069399066976,
+        "cp_point": 1.833,
+        "cpk_point": 1.79,
         "cp_interval": [
-            0.8212283592613202, 2.7081476775023385
+            0.821, 2.708
         ],
         "cpk_interval": [
-            0.6439789223401619, 2.47248884761527
-        ]
+            0.644, 2.472
+        ],
+        "error": null
     },
     "file532": {
         "data": [
@@ -8915,14 +9583,15 @@
         "lower_extreme": null,
         "upper_specification": 46.25,
         "lower_specification": 46.0,
-        "cp_point": 3.391867120596659,
-        "cpk_point": 1.3661282027350068,
+        "cp_point": 3.392,
+        "cpk_point": 1.366,
         "cp_interval": [
-            1.7799367807987259, 4.654614492558914
+            1.78, 4.655
         ],
         "cpk_interval": [
-            0.6881190443914285, 2.021062149062215
-        ]
+            0.688, 2.021
+        ],
+        "error": null
     },
     "file533": {
         "data": [
@@ -8932,14 +9601,15 @@
         "lower_extreme": null,
         "upper_specification": 55.85,
         "lower_specification": 55.7,
-        "cp_point": 2.726473214173264,
-        "cpk_point": 1.9722960910498795,
+        "cp_point": 2.726,
+        "cpk_point": 1.972,
         "cp_interval": [
-            1.5319271238517727, 3.624797037917052
+            1.532, 3.625
         ],
         "cpk_interval": [
-            0.9341490833597238, 2.8844423081486266
-        ]
+            0.934, 2.884
+        ],
+        "error": null
     },
     "file534": {
         "data": [
@@ -8949,14 +9619,15 @@
         "lower_extreme": null,
         "upper_specification": 54.94,
         "lower_specification": 54.882,
-        "cp_point": 1.1578890910027115,
-        "cpk_point": 0.6705806385755616,
+        "cp_point": 1.158,
+        "cpk_point": 0.671,
         "cp_interval": [
-            0.5035637801772145, 1.711111791087349
+            0.504, 1.711
         ],
         "cpk_interval": [
-            0.2107611788442284, 1.1341075739823105
-        ]
+            0.211, 1.134
+        ],
+        "error": null
     },
     "file535": {
         "data": [
@@ -8966,14 +9637,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 3.559174881111746,
-        "cpk_point": 1.9867588230415272,
+        "cp_point": 3.559,
+        "cpk_point": 1.987,
         "cp_interval": [
-            1.8711702559172627, 4.974160115902567
+            1.871, 4.974
         ],
         "cpk_interval": [
-            1.0894550740374058, 2.7920184505549637
-        ]
+            1.089, 2.792
+        ],
+        "error": null
     },
     "file536": {
         "data": [
@@ -8983,14 +9655,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.2531250342108358,
-        "cpk_point": 2.1163906199942333,
+        "cp_point": 2.253,
+        "cpk_point": 2.116,
         "cp_interval": [
-            1.055229183249619, 3.295276301846035
+            1.055, 3.295
         ],
         "cpk_interval": [
-            0.8368233894133476, 3.2045913203960747
-        ]
+            0.837, 3.205
+        ],
+        "error": null
     },
     "file537": {
         "data": [
@@ -9000,14 +9673,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 3.8610049773349795,
-        "cpk_point": 1.2347204199601698,
+        "cp_point": 3.861,
+        "cpk_point": 1.235,
         "cp_interval": [
-            2.035741989672968, 5.297066063906968
+            2.036, 5.297
         ],
         "cpk_interval": [
-            0.6448154996665546, 1.8053271421689672
-        ]
+            0.645, 1.805
+        ],
+        "error": null
     },
     "file538": {
         "data": [
@@ -9017,14 +9691,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 2.113827853237429,
-        "cpk_point": 2.0117478245234515,
+        "cp_point": 2.114,
+        "cpk_point": 2.012,
         "cp_interval": [
-            0.00015940889817479747, 2.990373631879409
+            0.0, 2.99
         ],
         "cpk_interval": [
-            0.00011718626295286731, 2.73464367866621
-        ]
+            0.0, 2.735
+        ],
+        "error": null
     },
     "file539": {
         "data": [
@@ -9034,14 +9709,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 1.026751239708734,
-        "cpk_point": 0.7585836639462401,
+        "cp_point": 1.339,
+        "cpk_point": 1.271,
         "cp_interval": [
-            0.5038893093744994, 1.3109749133418025
+            0.657, 1.71
         ],
         "cpk_interval": [
-            0.3750712982598773, 0.9913833001296614
-        ]
+            0.438, 2.058
+        ],
+        "error": null
     },
     "file540": {
         "data": [
@@ -9051,14 +9727,15 @@
         "lower_extreme": null,
         "upper_specification": 39.223,
         "lower_specification": 39.207,
-        "cp_point": 1.0243498878640096,
-        "cpk_point": 1.0145932483962918,
+        "cp_point": 1.024,
+        "cpk_point": 1.015,
         "cp_interval": [
-            0.9411182420146841, 1.06685200238117
+            0.941, 1.067
         ],
         "cpk_interval": [
-            0.8943776314929456, 1.0493898514709608
-        ]
+            0.894, 1.049
+        ],
+        "error": null
     },
     "file541": {
         "data": [
@@ -9068,14 +9745,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.05,
         "lower_specification": null,
-        "cp_point": 0.8155163610311023,
-        "cpk_point": 0.7892094465237826,
+        "cp_point": 0.82,
+        "cpk_point": 0.789,
         "cp_interval": [
-            0.5751835792942397, 1.0779650305430901
+            0.578, 1.083
         ],
         "cpk_interval": [
-            0.5298858003659015, 0.9907011960517136
-        ]
+            0.53, 1.096
+        ],
+        "error": null
     },
     "file542": {
         "data": [
@@ -9085,14 +9763,15 @@
         "lower_extreme": null,
         "upper_specification": 39.848,
         "lower_specification": 39.832,
-        "cp_point": 0.9804412426906441,
-        "cpk_point": 0.9094577858242635,
+        "cp_point": 0.98,
+        "cpk_point": 0.909,
         "cp_interval": [
-            0.9150429931046976, 1.0237791514508159
+            0.915, 1.024
         ],
         "cpk_interval": [
-            0.8251976503809292, 0.9814331879430981
-        ]
+            0.825, 0.981
+        ],
+        "error": null
     },
     "file543": {
         "data": [
@@ -9102,14 +9781,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.05,
         "lower_specification": null,
-        "cp_point": 0.9595665288614169,
-        "cpk_point": 0.9524678904471825,
+        "cp_point": 0.964,
+        "cpk_point": 0.952,
         "cp_interval": [
-            0.7280893388912092, 1.2107776849468437
+            0.732, 1.217
         ],
         "cpk_interval": [
-            0.6912782413982286, 1.0187906372411333
-        ]
+            0.691, 1.257
+        ],
+        "error": null
     },
     "file544": {
         "data": [
@@ -9119,14 +9799,15 @@
         "lower_extreme": null,
         "upper_specification": 34.513,
         "lower_specification": 34.497,
-        "cp_point": 0.9429926759185272,
-        "cpk_point": 0.8889769842138541,
+        "cp_point": 0.943,
+        "cpk_point": 0.889,
         "cp_interval": [
-            0.8721028297636619, 1.0034483823600393
+            0.872, 1.003
         ],
         "cpk_interval": [
-            0.8118405139041428, 0.9721089297706738
-        ]
+            0.812, 0.972
+        ],
+        "error": null
     },
     "file545": {
         "data": [
@@ -9136,14 +9817,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.05,
         "lower_specification": null,
-        "cp_point": 0.9484184549912917,
-        "cpk_point": 0.9416686322637422,
+        "cp_point": 0.955,
+        "cpk_point": 0.942,
         "cp_interval": [
-            0.2971664001954833, 1.3373090439658954
+            0.299, 1.346
         ],
         "cpk_interval": [
-            0.2539909041404512, 0.9957262048708696
-        ]
+            0.254, 1.462
+        ],
+        "error": null
     },
     "file546": {
         "data": [
@@ -9153,14 +9835,15 @@
         "lower_extreme": null,
         "upper_specification": 44.025,
         "lower_specification": 44.009,
-        "cp_point": 1.4235306361120377,
-        "cpk_point": 1.2915648875815513,
+        "cp_point": 1.424,
+        "cpk_point": 1.292,
         "cp_interval": [
-            1.323482083137299, 1.5161961571673426
+            1.323, 1.516
         ],
         "cpk_interval": [
-            1.1924829843774247, 1.3923717326387444
-        ]
+            1.192, 1.392
+        ],
+        "error": null
     },
     "file547": {
         "data": [
@@ -9170,14 +9853,15 @@
         "lower_extreme": null,
         "upper_specification": 44.025,
         "lower_specification": 44.009,
-        "cp_point": 1.4645232484102466,
-        "cpk_point": 1.2803733393426278,
+        "cp_point": 1.465,
+        "cpk_point": 1.28,
         "cp_interval": [
-            1.3553233005630576, 1.563396650664362
+            1.355, 1.563
         ],
         "cpk_interval": [
-            1.17210220176241, 1.3925205180876294
-        ]
+            1.172, 1.393
+        ],
+        "error": null
     },
     "file548": {
         "data": [
@@ -9187,14 +9871,15 @@
         "lower_extreme": null,
         "upper_specification": 28.02,
         "lower_specification": 28.009,
-        "cp_point": 1.0514415560101678,
-        "cpk_point": 0.9086168942200354,
+        "cp_point": 1.051,
+        "cpk_point": 0.909,
         "cp_interval": [
-            0.979049442468401, 1.1167257180287877
+            0.979, 1.117
         ],
         "cpk_interval": [
-            0.8371373934066962, 0.9626953277010536
-        ]
+            0.837, 0.963
+        ],
+        "error": null
     },
     "file549": {
         "data": [
@@ -9204,14 +9889,15 @@
         "lower_extreme": null,
         "upper_specification": 28.02,
         "lower_specification": 28.009,
-        "cp_point": 1.0741072806662098,
-        "cpk_point": 1.0296924959016753,
+        "cp_point": 1.074,
+        "cpk_point": 1.03,
         "cp_interval": [
-            1.0031800660038879, 1.1331821349694204
+            1.003, 1.133
         ],
         "cpk_interval": [
-            0.9362757104746466, 1.1088303003336644
-        ]
+            0.936, 1.109
+        ],
+        "error": null
     },
     "file550": {
         "data": [
@@ -9221,14 +9907,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.005,
         "lower_specification": null,
-        "cp_point": 1.1798660270260126,
-        "cpk_point": 0.9849900755896418,
+        "cp_point": 1.183,
+        "cpk_point": 1.223,
         "cp_interval": [
-            1.0225341116279028, 1.3408345661166803
+            1.025, 1.345
         ],
         "cpk_interval": [
-            0.9812995755622882, 0.9895276358362876
-        ]
+            1.03, 1.425
+        ],
+        "error": null
     },
     "file551": {
         "data": [
@@ -9238,14 +9925,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.005,
         "lower_specification": null,
-        "cp_point": 0.8830842084916221,
-        "cpk_point": 0.838996659438952,
+        "cp_point": 0.889,
+        "cpk_point": 0.839,
         "cp_interval": [
-            0.8024416937715458, 0.9624014398897628
+            0.808, 0.969
         ],
         "cpk_interval": [
-            0.7339070202602127, 0.9524276687789803
-        ]
+            0.734, 0.952
+        ],
+        "error": null
     },
     "file552": {
         "data": [
@@ -9255,14 +9943,15 @@
         "lower_extreme": null,
         "upper_specification": 28.16,
         "lower_specification": 27.96,
-        "cp_point": 1.0174488290140866,
-        "cpk_point": 0.7677116512068884,
+        "cp_point": 1.017,
+        "cpk_point": 0.768,
         "cp_interval": [
-            0.903474074908749, 1.152948655458314
+            0.903, 1.153
         ],
         "cpk_interval": [
-            0.6565860492588383, 0.9031094005379977
-        ]
+            0.657, 0.903
+        ],
+        "error": null
     },
     "file553": {
         "data": [
@@ -9272,14 +9961,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.024047232089977,
-        "cpk_point": 0.8099323973875362,
+        "cp_point": 1.14,
+        "cpk_point": 1.057,
         "cp_interval": [
-            0.004982482174697382, 2.458286269541046
+            0.006, 2.738
         ],
         "cpk_interval": [
-            0.004475954230812667, 0.8781484957807415
-        ]
+            0.004, 3.206
+        ],
+        "error": null
     },
     "file554": {
         "data": [
@@ -9289,14 +9979,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.1209192735835094,
-        "cpk_point": 0.7872345470394434,
+        "cp_point": 1.249,
+        "cpk_point": 1.19,
         "cp_interval": [
-            0.8250485644071542, 1.4375888215292292
+            0.919, 1.602
         ],
         "cpk_interval": [
-            0.7118789404513088, 0.8442469896716214
-        ]
+            0.839, 1.596
+        ],
+        "error": null
     },
     "file555": {
         "data": [
@@ -9306,14 +9997,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.6495534332338408,
-        "cpk_point": 0.744768134994721,
+        "cp_point": 1.846,
+        "cpk_point": 1.939,
         "cp_interval": [
-            1.0860440824565654, 2.2119980256611322
+            1.215, 2.476
         ],
         "cpk_interval": [
-            0.6024497993490456, 0.8445068982784604
-        ]
+            1.183, 2.766
+        ],
+        "error": null
     },
     "file556": {
         "data": [
@@ -9323,14 +10015,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.498548124954466,
-        "cpk_point": 0.7482058335725538,
+        "cp_point": 1.677,
+        "cpk_point": 1.72,
         "cp_interval": [
-            0.962646535040342, 2.0414997588460957
+            1.078, 2.285
         ],
         "cpk_interval": [
-            0.6071413231755254, 0.8467689244803006
-        ]
+            1.024, 2.5
+        ],
+        "error": null
     },
     "file557": {
         "data": [
@@ -9340,14 +10033,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.04478478535451,
-        "cpk_point": 0.9530324602606999,
+        "cp_point": 1.06,
+        "cpk_point": 1.069,
         "cp_interval": [
-            0.6231253693225492, 1.5548777515310572
+            0.632, 1.577
         ],
         "cpk_interval": [
-            0.5815321367262514, 1.0359692355896863
-        ]
+            0.582, 1.787
+        ],
+        "error": null
     },
     "file558": {
         "data": [
@@ -9357,14 +10051,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.477937184845693,
-        "cpk_point": 1.0053557999833114,
+        "cp_point": 1.556,
+        "cpk_point": 1.652,
         "cp_interval": [
-            1.2252124270418367, 1.7287249552207773
+            1.29, 1.82
         ],
         "cpk_interval": [
-            0.9335931847163882, 1.0623026054305797
-        ]
+            1.315, 2.007
+        ],
+        "error": null
     },
     "file559": {
         "data": [
@@ -9373,7 +10068,16 @@
         "upper_extreme": null,
         "lower_extreme": null,
         "upper_specification": 7.0,
-        "lower_specification": -7.0
+        "lower_specification": -7.0,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More data points are required to calculate capability indexes."
     },
     "file560": {
         "data": [
@@ -9382,7 +10086,16 @@
         "upper_extreme": null,
         "lower_extreme": null,
         "upper_specification": 7.0,
-        "lower_specification": -7.0
+        "lower_specification": -7.0,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More data points are required to calculate capability indexes."
     },
     "file561": {
         "data": [
@@ -9391,7 +10104,16 @@
         "upper_extreme": null,
         "lower_extreme": null,
         "upper_specification": 7.0,
-        "lower_specification": -7.0
+        "lower_specification": -7.0,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More data points are required to calculate capability indexes."
     },
     "file562": {
         "data": [
@@ -9401,14 +10123,15 @@
         "lower_extreme": null,
         "upper_specification": 12.0,
         "lower_specification": 4.0,
-        "cp_point": 3.262494305933731,
-        "cpk_point": 3.159552499944919,
+        "cp_point": 3.262,
+        "cpk_point": 3.16,
         "cp_interval": [
-            2.8203716337876887, 3.4819862387736427
+            2.82, 3.482
         ],
         "cpk_interval": [
-            2.6131363570733352, 3.349662486428061
-        ]
+            2.613, 3.35
+        ],
+        "error": null
     },
     "file563": {
         "data": [
@@ -9417,7 +10140,16 @@
         "upper_extreme": null,
         "lower_extreme": null,
         "upper_specification": 7.0,
-        "lower_specification": -7.0
+        "lower_specification": -7.0,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More unique values are required to calculate capability indexes."
     },
     "file564": {
         "data": [
@@ -9427,14 +10159,15 @@
         "lower_extreme": null,
         "upper_specification": 20.0,
         "lower_specification": 10.0,
-        "cp_point": 1.0750260038779225,
-        "cpk_point": 0.707893573194612,
+        "cp_point": 1.075,
+        "cpk_point": 0.708,
         "cp_interval": [
-            0.009456360376723462, 2.490935562951803
+            0.009, 2.491
         ],
         "cpk_interval": [
-            0.005290915579761702, 2.2627295450184968
-        ]
+            0.005, 2.263
+        ],
+        "error": null
     },
     "file565": {
         "data": [
@@ -9444,14 +10177,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 1.9281717576797914,
-        "cpk_point": 1.5348881023308072,
+        "cp_point": 1.928,
+        "cpk_point": 1.535,
         "cp_interval": [
-            1.5673668391076032, 2.2404396900824937
+            1.567, 2.24
         ],
         "cpk_interval": [
-            1.2070206661546745, 1.7991689871752767
-        ]
+            1.207, 1.799
+        ],
+        "error": null
     },
     "file566": {
         "data": [
@@ -9461,14 +10195,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": 1.0,
-        "cp_point": 1.9184722618561456,
-        "cpk_point": 1.9182885674037746,
+        "cp_point": 1.918,
+        "cpk_point": 1.918,
         "cp_interval": [
-            1.6556561454129337, 2.16005388903526
+            1.656, 2.16
         ],
         "cpk_interval": [
-            1.6425331405485681, 2.1292693000730494
-        ]
+            1.643, 2.129
+        ],
+        "error": null
     },
     "file567": {
         "data": [
@@ -9478,14 +10213,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 1.9007288030433926,
-        "cpk_point": 1.4100073385836265,
+        "cp_point": 1.901,
+        "cpk_point": 1.41,
         "cp_interval": [
-            1.5454130986048125, 2.208205286622545
+            1.545, 2.208
         ],
         "cpk_interval": [
-            1.1103621380408515, 1.6530894293581804
-        ]
+            1.11, 1.653
+        ],
+        "error": null
     },
     "file568": {
         "data": [
@@ -9495,14 +10231,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": 1.0,
-        "cp_point": 1.732426997395641,
-        "cpk_point": 1.2896782398864797,
+        "cp_point": 1.732,
+        "cpk_point": 1.29,
         "cp_interval": [
-            1.5040298171757527, 1.8209149284986323
+            1.504, 1.821
         ],
         "cpk_interval": [
-            1.0812050073461745, 1.3878561843885813
-        ]
+            1.081, 1.388
+        ],
+        "error": null
     },
     "file569": {
         "data": [
@@ -9512,14 +10249,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 1.6265799237351908,
-        "cpk_point": 1.3878826368865693,
+        "cp_point": 1.627,
+        "cpk_point": 1.388,
         "cp_interval": [
-            1.3466345660658088, 1.8751429300457234
+            1.347, 1.875
         ],
         "cpk_interval": [
-            1.1671579949241313, 1.5974463789130866
-        ]
+            1.167, 1.597
+        ],
+        "error": null
     },
     "file570": {
         "data": [
@@ -9529,14 +10267,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 1.0,
-        "cp_point": 2.806553511470333,
-        "cpk_point": 2.399104159118568,
+        "cp_point": 2.807,
+        "cpk_point": 2.399,
         "cp_interval": [
-            2.3891850995732264, 3.1677720423023445
+            2.389, 3.168
         ],
         "cpk_interval": [
-            1.9923268609487241, 2.7588315722598784
-        ]
+            1.992, 2.759
+        ],
+        "error": null
     },
     "file571": {
         "data": [
@@ -9546,14 +10285,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 2.128713173553258,
-        "cpk_point": 2.084475763479024,
+        "cp_point": 2.129,
+        "cpk_point": 2.084,
         "cp_interval": [
-            1.851785751655183, 2.4040652209855877
+            1.852, 2.404
         ],
         "cpk_interval": [
-            1.6680729174365276, 2.307022876204929
-        ]
+            1.668, 2.307
+        ],
+        "error": null
     },
     "file572": {
         "data": [
@@ -9563,14 +10303,15 @@
         "lower_extreme": null,
         "upper_specification": 18.0,
         "lower_specification": 12.0,
-        "cp_point": 1.8336403186658303,
-        "cpk_point": 1.3276420850108102,
+        "cp_point": 1.834,
+        "cpk_point": 1.328,
         "cp_interval": [
-            1.5581275152373828, 2.1021440593040395
+            1.558, 2.102
         ],
         "cpk_interval": [
-            1.1026204978340268, 1.5526422399526913
-        ]
+            1.103, 1.553
+        ],
+        "error": null
     },
     "file573": {
         "data": [
@@ -9580,14 +10321,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 3.0244907205421585,
-        "cpk_point": 0.8553081486536865,
+        "cp_point": 3.363,
+        "cpk_point": 5.127,
         "cp_interval": [
-            2.545573242687635, 3.465861790201973
+            2.831, 3.854
         ],
         "cpk_interval": [
-            0.6779429910449284, 0.974335494622263
-        ]
+            3.781, 6.597
+        ],
+        "error": null
     },
     "file574": {
         "data": [
@@ -9597,14 +10339,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 2.7925988547945053,
-        "cpk_point": 0.8618641040318874,
+        "cp_point": 3.108,
+        "cpk_point": 4.396,
         "cp_interval": [
-            2.29814800812081, 3.187685354524221
+            2.558, 3.548
         ],
         "cpk_interval": [
-            0.7024848260573768, 0.9631083982600739
-        ]
+            3.257, 5.578
+        ],
+        "error": null
     },
     "file575": {
         "data": [
@@ -9614,14 +10357,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 1.69095009271071,
-        "cpk_point": 1.4444170085976018,
+        "cp_point": 1.691,
+        "cpk_point": 1.444,
         "cp_interval": [
-            1.359272921093591, 1.983027916029895
+            1.359, 1.983
         ],
         "cpk_interval": [
-            1.121119347326274, 1.7760341251947795
-        ]
+            1.121, 1.776
+        ],
+        "error": null
     },
     "file576": {
         "data": [
@@ -9631,14 +10375,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.9128687677159584,
-        "cpk_point": 0.8929925369944078,
+        "cp_point": 1.985,
+        "cpk_point": 2.387,
         "cp_interval": [
-            1.6448450682310987, 2.174012273785801
+            1.707, 2.256
         ],
         "cpk_interval": [
-            0.8387655348863398, 0.9397291529817872
-        ]
+            1.966, 2.798
+        ],
+        "error": null
     },
     "file577": {
         "data": [
@@ -9648,14 +10393,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 1.663097323345456,
-        "cpk_point": 1.3502217324992567,
+        "cp_point": 1.663,
+        "cpk_point": 1.35,
         "cp_interval": [
-            1.3625165511240431, 1.9368926367174817
+            1.363, 1.937
         ],
         "cpk_interval": [
-            1.077471716353306, 1.627426778088671
-        ]
+            1.077, 1.627
+        ],
+        "error": null
     },
     "file578": {
         "data": [
@@ -9665,14 +10411,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 2.3793408722307814,
-        "cpk_point": 0.8536478915621719,
+        "cp_point": 2.648,
+        "cpk_point": 3.53,
         "cp_interval": [
-            2.0822030140975625, 2.6548837421288383
+            2.318, 2.955
         ],
         "cpk_interval": [
-            0.7621736313185196, 0.9255255678280818
-        ]
+            3.013, 3.995
+        ],
+        "error": null
     },
     "file579": {
         "data": [
@@ -9682,14 +10429,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 1.4067348149570982,
-        "cpk_point": 0.7369344862344462,
+        "cp_point": 1.407,
+        "cpk_point": 0.737,
         "cp_interval": [
-            1.1605694196314673, 1.6323087410180075
+            1.161, 1.632
         ],
         "cpk_interval": [
-            0.5844081273539611, 0.9060724578926372
-        ]
+            0.584, 0.906
+        ],
+        "error": null
     },
     "file580": {
         "data": [
@@ -9699,14 +10447,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 1.4100887874608683,
-        "cpk_point": 0.942050811953739,
+        "cp_point": 1.477,
+        "cpk_point": 1.65,
         "cp_interval": [
-            1.2144150370521671, 1.5977146448574922
+            1.272, 1.674
         ],
         "cpk_interval": [
-            0.882751944603651, 0.9928169943621591
-        ]
+            1.36, 1.942
+        ],
+        "error": null
     },
     "file581": {
         "data": [
@@ -9716,14 +10465,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 1.5564766814082227,
-        "cpk_point": 1.1453706836970723,
+        "cp_point": 1.556,
+        "cpk_point": 1.145,
         "cp_interval": [
-            1.2901296445531918, 1.801655214794576
+            1.29, 1.802
         ],
         "cpk_interval": [
-            0.9484540823507963, 1.3460628452343155
-        ]
+            0.948, 1.346
+        ],
+        "error": null
     },
     "file582": {
         "data": [
@@ -9733,14 +10483,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 8.97598918121781,
-        "cpk_point": 0.7368428803938656,
+        "cp_point": 9.198,
+        "cpk_point": 11.981,
         "cp_interval": [
-            6.163892673240911, 11.717597272362573
+            6.316, 12.008
         ],
         "cpk_interval": [
-            0.593895719098599, 0.8384025358505236
-        ]
+            7.649, 16.343
+        ],
+        "error": null
     },
     "file583": {
         "data": [
@@ -9750,14 +10501,15 @@
         "lower_extreme": null,
         "upper_specification": 46.25,
         "lower_specification": 46.0,
-        "cp_point": 1.7126281986702332,
-        "cpk_point": 0.07683239172564568,
+        "cp_point": 1.713,
+        "cpk_point": 0.077,
         "cp_interval": [
-            1.4800299908473142, 1.9302229521485246
+            1.48, 1.93
         ],
         "cpk_interval": [
-            0.029275712853862615, 0.14277869915259878
-        ]
+            0.029, 0.143
+        ],
+        "error": null
     },
     "file584": {
         "data": [
@@ -9767,14 +10519,15 @@
         "lower_extreme": null,
         "upper_specification": 55.85,
         "lower_specification": 55.7,
-        "cp_point": 1.7856648719971793,
-        "cpk_point": 1.6630682817447398,
+        "cp_point": 1.786,
+        "cpk_point": 1.663,
         "cp_interval": [
-            1.5238093239229895, 2.024882020653505
+            1.524, 2.025
         ],
         "cpk_interval": [
-            1.3898272902527764, 1.9330246399412916
-        ]
+            1.39, 1.933
+        ],
+        "error": null
     },
     "file585": {
         "data": [
@@ -9784,14 +10537,15 @@
         "lower_extreme": null,
         "upper_specification": 54.94,
         "lower_specification": 54.882,
-        "cp_point": 0.855974971694502,
-        "cpk_point": 0.5114050680122432,
+        "cp_point": 0.856,
+        "cpk_point": 0.511,
         "cp_interval": [
-            0.7379621602458141, 0.9642616541159804
+            0.738, 0.964
         ],
         "cpk_interval": [
-            0.42764237319684173, 0.6148430711915874
-        ]
+            0.428, 0.615
+        ],
+        "error": null
     },
     "file586": {
         "data": [
@@ -9801,14 +10555,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.6870127404748274,
-        "cpk_point": 2.2785251786582963,
+        "cp_point": 2.687,
+        "cpk_point": 2.279,
         "cp_interval": [
-            2.370629217733418, 2.9800457992725327
+            2.371, 2.98
         ],
         "cpk_interval": [
-            1.8977400834712332, 2.741469032666309
-        ]
+            1.898, 2.741
+        ],
+        "error": null
     },
     "file587": {
         "data": [
@@ -9818,14 +10573,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.1475702381534476,
-        "cpk_point": 1.412800748379124,
+        "cp_point": 2.148,
+        "cpk_point": 1.413,
         "cp_interval": [
-            1.8494740988286977, 2.421171258245429
+            1.849, 2.421
         ],
         "cpk_interval": [
-            1.1959139623917274, 1.6288022644921007
-        ]
+            1.196, 1.629
+        ],
+        "error": null
     },
     "file588": {
         "data": [
@@ -9835,14 +10591,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 1.9347793059790825,
-        "cpk_point": 1.9093693846547288,
+        "cp_point": 1.935,
+        "cpk_point": 1.909,
         "cp_interval": [
-            1.6634930947693942, 2.1861143108838017
+            1.663, 2.186
         ],
         "cpk_interval": [
-            1.64137605223809, 2.1302145330198043
-        ]
+            1.641, 2.13
+        ],
+        "error": null
     },
     "file589": {
         "data": [
@@ -9852,14 +10609,15 @@
         "lower_extreme": null,
         "upper_specification": 13.0,
         "lower_specification": -13.0,
-        "cp_point": 2.4837542360469222,
-        "cpk_point": 1.6644404717534083,
+        "cp_point": 2.484,
+        "cpk_point": 1.664,
         "cp_interval": [
-            2.1312273307137195, 2.8070166877817884
+            2.131, 2.807
         ],
         "cpk_interval": [
-            1.3989340525002711, 1.924183070752606
-        ]
+            1.399, 1.924
+        ],
+        "error": null
     },
     "file590": {
         "data": [
@@ -9869,14 +10627,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.4334290401546831,
-        "cpk_point": 0.3141555514142549,
+        "cp_point": 0.875,
+        "cpk_point": 0.314,
         "cp_interval": [
-            0.35157083559148516, 0.5148908156887109
+            0.71, 1.039
         ],
         "cpk_interval": [
-            0.23575336592378052, 0.40338679994251986
-        ]
+            0.236, 0.403
+        ],
+        "error": null
     },
     "file591": {
         "data": [
@@ -9886,14 +10645,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.6677999763038638,
-        "cpk_point": 0.6401693732024764,
+        "cp_point": 0.805,
+        "cpk_point": 0.64,
         "cp_interval": [
-            0.5171360752517612, 0.8251106657802775
+            0.624, 0.995
         ],
         "cpk_interval": [
-            0.4757263022686396, 0.7971227672927609
-        ]
+            0.476, 0.837
+        ],
+        "error": null
     },
     "file592": {
         "data": [
@@ -9903,14 +10663,15 @@
         "lower_extreme": null,
         "upper_specification": -21.0,
         "lower_specification": -39.0,
-        "cp_point": 0.6733947523895668,
-        "cpk_point": 0.34858072220112307,
+        "cp_point": 0.673,
+        "cpk_point": 0.349,
         "cp_interval": [
-            0.5280157552948628, 0.8361348011826398
+            0.528, 0.836
         ],
         "cpk_interval": [
-            0.2490426247783383, 0.4565353024230853
-        ]
+            0.249, 0.457
+        ],
+        "error": null
     },
     "file593": {
         "data": [
@@ -9920,14 +10681,15 @@
         "lower_extreme": null,
         "upper_specification": 10.0,
         "lower_specification": 2.0,
-        "cp_point": 1.5635649059091503,
-        "cpk_point": 0.9198950988765052,
+        "cp_point": 1.564,
+        "cpk_point": 0.92,
         "cp_interval": [
-            1.3889974890636867, 1.7200332828258666
+            1.389, 1.72
         ],
         "cpk_interval": [
-            0.8010772314484071, 1.0101214135234513
-        ]
+            0.801, 1.01
+        ],
+        "error": null
     },
     "file594": {
         "data": [
@@ -9937,14 +10699,15 @@
         "lower_extreme": null,
         "upper_specification": -21.0,
         "lower_specification": -39.0,
-        "cp_point": 0.7396941514327855,
-        "cpk_point": 0.5283836702232396,
+        "cp_point": 0.74,
+        "cpk_point": 0.528,
         "cp_interval": [
-            0.5967805870768634, 0.8716108252235691
+            0.597, 0.872
         ],
         "cpk_interval": [
-            0.403813316267293, 0.6272847648022005
-        ]
+            0.404, 0.627
+        ],
+        "error": null
     },
     "file595": {
         "data": [
@@ -9954,14 +10717,15 @@
         "lower_extreme": null,
         "upper_specification": 10.0,
         "lower_specification": 2.0,
-        "cp_point": 2.0239822294657954,
-        "cpk_point": 1.4582138759339403,
+        "cp_point": 2.024,
+        "cpk_point": 1.458,
         "cp_interval": [
-            1.7975132711621251, 2.233522559056961
+            1.798, 2.234
         ],
         "cpk_interval": [
-            1.2938390530953074, 1.6238604632785234
-        ]
+            1.294, 1.624
+        ],
+        "error": null
     },
     "file596": {
         "data": [
@@ -9971,14 +10735,15 @@
         "lower_extreme": null,
         "upper_specification": 9.0,
         "lower_specification": -9.0,
-        "cp_point": 0.7569765746646648,
-        "cpk_point": 0.4762908064519016,
+        "cp_point": 0.757,
+        "cpk_point": 0.476,
         "cp_interval": [
-            0.5981847838184691, 0.8930143236947216
+            0.598, 0.893
         ],
         "cpk_interval": [
-            0.33958560530654064, 0.6180350808964328
-        ]
+            0.34, 0.618
+        ],
+        "error": null
     },
     "file597": {
         "data": [
@@ -9988,14 +10753,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.0864973892984051,
-        "cpk_point": 0.41319464907247083,
+        "cp_point": 1.086,
+        "cpk_point": 0.413,
         "cp_interval": [
-            0.8901374022745661, 1.2418316452816365
+            0.89, 1.242
         ],
         "cpk_interval": [
-            0.29103954945406985, 0.5121155596239917
-        ]
+            0.291, 0.512
+        ],
+        "error": null
     },
     "file598": {
         "data": [
@@ -10005,14 +10771,15 @@
         "lower_extreme": null,
         "upper_specification": 9.0,
         "lower_specification": -9.0,
-        "cp_point": 0.6788844454340651,
-        "cpk_point": 0.535620674335732,
+        "cp_point": 0.679,
+        "cpk_point": 0.536,
         "cp_interval": [
-            0.5482113490816634, 0.7997919143432946
+            0.548, 0.8
         ],
         "cpk_interval": [
-            0.4113437750023629, 0.63473054839197
-        ]
+            0.411, 0.635
+        ],
+        "error": null
     },
     "file599": {
         "data": [
@@ -10022,14 +10789,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.7202433134777642,
-        "cpk_point": 0.6979428340081623,
+        "cp_point": 1.72,
+        "cpk_point": 0.698,
         "cp_interval": [
-            1.5185424530483904, 1.902196846944272
+            1.519, 1.902
         ],
         "cpk_interval": [
-            0.5986395582295095, 0.8087854575323007
-        ]
+            0.599, 0.809
+        ],
+        "error": null
     },
     "file600": {
         "data": [
@@ -10039,14 +10807,15 @@
         "lower_extreme": null,
         "upper_specification": 14.0,
         "lower_specification": 6.0,
-        "cp_point": 2.189777657118198,
-        "cpk_point": 1.99307584348079,
+        "cp_point": 2.19,
+        "cpk_point": 1.993,
         "cp_interval": [
-            1.9382493992337286, 2.447085814632234
+            1.938, 2.447
         ],
         "cpk_interval": [
-            1.7856001190944366, 2.23874461035828
-        ]
+            1.786, 2.239
+        ],
+        "error": null
     },
     "file601": {
         "data": [
@@ -10056,14 +10825,15 @@
         "lower_extreme": null,
         "upper_specification": 14.0,
         "lower_specification": 6.0,
-        "cp_point": 1.9081725125493831,
-        "cpk_point": 1.9043111265313921,
+        "cp_point": 1.908,
+        "cpk_point": 1.904,
         "cp_interval": [
-            1.4226039122659448, 2.2738823954556873
+            1.423, 2.274
         ],
         "cpk_interval": [
-            1.2369821412888056, 2.0731217145890817
-        ]
+            1.237, 2.073
+        ],
+        "error": null
     },
     "file602": {
         "data": [
@@ -10073,14 +10843,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 11.0,
         "lower_specification": null,
-        "cp_point": 0.3813759768078082,
-        "cpk_point": 0.26994149680207286,
+        "cp_point": 0.449,
+        "cpk_point": 0.27,
         "cp_interval": [
-            0.3107736195202391, 0.45613225465562
+            0.366, 0.538
         ],
         "cpk_interval": [
-            0.2059865473180665, 0.3481766934479545
-        ]
+            0.206, 0.348
+        ],
+        "error": null
     },
     "file603": {
         "data": [
@@ -10090,14 +10861,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 11.0,
         "lower_specification": null,
-        "cp_point": 0.43119359139545904,
-        "cpk_point": 0.31900484917776994,
+        "cp_point": 0.482,
+        "cpk_point": 0.319,
         "cp_interval": [
-            0.35040605906707195, 0.5170648011677925
+            0.392, 0.578
         ],
         "cpk_interval": [
-            0.24514906403254524, 0.40845006820313373
-        ]
+            0.245, 0.408
+        ],
+        "error": null
     },
     "file604": {
         "data": [
@@ -10107,14 +10879,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 20.0,
         "lower_specification": null,
-        "cp_point": 0.5151748812693365,
-        "cpk_point": 0.3768786555570047,
+        "cp_point": 0.565,
+        "cpk_point": 0.377,
         "cp_interval": [
-            0.4483199041455156, 0.5830077090918502
+            0.491, 0.639
         ],
         "cpk_interval": [
-            0.30822516203474687, 0.46019290664259915
-        ]
+            0.308, 0.46
+        ],
+        "error": null
     },
     "file605": {
         "data": [
@@ -10124,14 +10897,15 @@
         "lower_extreme": null,
         "upper_specification": 41.94,
         "lower_specification": 41.67,
-        "cp_point": 1.9622277509264296,
-        "cpk_point": 1.7258946887878601,
+        "cp_point": 1.962,
+        "cpk_point": 1.726,
         "cp_interval": [
-            1.7586967396250506, 2.1324601767703273
+            1.759, 2.132
         ],
         "cpk_interval": [
-            1.5223677202959767, 1.952269055508415
-        ]
+            1.522, 1.952
+        ],
+        "error": null
     },
     "file606": {
         "data": [
@@ -10141,14 +10915,15 @@
         "lower_extreme": null,
         "upper_specification": 53.0,
         "lower_specification": 52.85,
-        "cp_point": 1.0584460148176336,
-        "cpk_point": 0.5375401242761069,
+        "cp_point": 1.058,
+        "cpk_point": 0.538,
         "cp_interval": [
-            0.9151942152503076, 1.1841285254847782
+            0.915, 1.184
         ],
         "cpk_interval": [
-            0.4449608298596471, 0.6149487005835297
-        ]
+            0.445, 0.615
+        ],
+        "error": null
     },
     "file607": {
         "data": [
@@ -10158,14 +10933,15 @@
         "lower_extreme": null,
         "upper_specification": 50.122,
         "lower_specification": 50.077,
-        "cp_point": 0.6417305129597441,
-        "cpk_point": 0.4858761909010766,
+        "cp_point": 0.642,
+        "cpk_point": 0.486,
         "cp_interval": [
-            0.2745701591555142, 0.8232278860103989
+            0.275, 0.823
         ],
         "cpk_interval": [
-            0.15203660135887634, 0.7363936558056509
-        ]
+            0.152, 0.736
+        ],
+        "error": null
     },
     "file608": {
         "data": [
@@ -10175,14 +10951,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": -5.0,
-        "cp_point": 1.5549042584738286,
-        "cpk_point": 1.3041070129653292,
+        "cp_point": 1.555,
+        "cpk_point": 1.304,
         "cp_interval": [
-            1.396137373181403, 1.683417808177558
+            1.396, 1.683
         ],
         "cpk_interval": [
-            1.1652854000881776, 1.4682812550512405
-        ]
+            1.165, 1.468
+        ],
+        "error": null
     },
     "file609": {
         "data": [
@@ -10192,14 +10969,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": -5.0,
-        "cp_point": 2.076324066306769,
-        "cpk_point": 1.9449259511971564,
+        "cp_point": 2.076,
+        "cpk_point": 1.945,
         "cp_interval": [
-            1.8425306122124294, 2.2496004989510907
+            1.843, 2.25
         ],
         "cpk_interval": [
-            1.6531210362462734, 2.1920945210164606
-        ]
+            1.653, 2.192
+        ],
+        "error": null
     },
     "file610": {
         "data": [
@@ -10209,14 +10987,15 @@
         "lower_extreme": null,
         "upper_specification": -21.0,
         "lower_specification": -39.0,
-        "cp_point": 2.4403599082028458,
-        "cpk_point": 2.101820773729679,
+        "cp_point": 2.44,
+        "cpk_point": 2.102,
         "cp_interval": [
-            2.1364721933649684, 2.7045937675442686
+            2.136, 2.705
         ],
         "cpk_interval": [
-            1.7999323797649642, 2.358989798861201
-        ]
+            1.8, 2.359
+        ],
+        "error": null
     },
     "file611": {
         "data": [
@@ -10226,14 +11005,15 @@
         "lower_extreme": null,
         "upper_specification": 9.0,
         "lower_specification": -9.0,
-        "cp_point": 1.9560311437800484,
-        "cpk_point": 1.5847875163404215,
+        "cp_point": 1.956,
+        "cpk_point": 1.585,
         "cp_interval": [
-            1.7053115147009235, 2.1747268523026926
+            1.705, 2.175
         ],
         "cpk_interval": [
-            1.3506067284829222, 1.7730948662247263
-        ]
+            1.351, 1.773
+        ],
+        "error": null
     },
     "file612": {
         "data": [
@@ -10243,14 +11023,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.576518984517439,
-        "cpk_point": 0.4065440693809073,
+        "cp_point": 0.731,
+        "cpk_point": 0.407,
         "cp_interval": [
-            0.5119696332065137, 0.6556537308728664
+            0.649, 0.831
         ],
         "cpk_interval": [
-            0.33292833644115577, 0.4907088324605466
-        ]
+            0.333, 0.491
+        ],
+        "error": null
     },
     "file613": {
         "data": [
@@ -10260,14 +11041,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.8126141874066394,
-        "cpk_point": 0.8049874427845674,
+        "cp_point": 0.982,
+        "cpk_point": 0.805,
         "cp_interval": [
-            0.6834610635060315, 0.9412372647125123
+            0.826, 1.137
         ],
         "cpk_interval": [
-            0.6517002814353803, 0.8844229070564508
-        ]
+            0.652, 0.971
+        ],
+        "error": null
     },
     "file614": {
         "data": [
@@ -10277,14 +11059,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.3628148335666133,
-        "cpk_point": 0.8760922247908745,
+        "cp_point": 1.525,
+        "cpk_point": 1.655,
         "cp_interval": [
-            1.2252890568000783, 1.4944558709551212
+            1.371, 1.672
         ],
         "cpk_interval": [
-            0.8094536721533108, 0.9231835165265987
-        ]
+            1.439, 1.909
+        ],
+        "error": null
     },
     "file615": {
         "data": [
@@ -10294,14 +11077,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.625854484969252,
-        "cpk_point": 0.886324682764239,
+        "cp_point": 1.825,
+        "cpk_point": 2.42,
         "cp_interval": [
-            1.4991055425293374, 1.7512356757461855
+            1.683, 1.966
         ],
         "cpk_interval": [
-            0.8100783767225463, 0.9516971884750741
-        ]
+            2.124, 2.763
+        ],
+        "error": null
     },
     "file616": {
         "data": [
@@ -10311,14 +11095,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.33904185947667587,
-        "cpk_point": 0.2435560319465553,
+        "cp_point": 0.383,
+        "cpk_point": 0.244,
         "cp_interval": [
-            0.2117506846985382, 0.4216993577145567
+            0.239, 0.476
         ],
         "cpk_interval": [
-            0.143301099292138, 0.3174165650168635
-        ]
+            0.143, 0.317
+        ],
+        "error": null
     },
     "file617": {
         "data": [
@@ -10328,14 +11113,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.328826844253645,
-        "cpk_point": 0.24853249366418076,
+        "cp_point": 0.368,
+        "cpk_point": 0.249,
         "cp_interval": [
-            0.19630611060388864, 0.40022934406607685
+            0.22, 0.448
         ],
         "cpk_interval": [
-            0.13612906547982362, 0.31695361394421584
-        ]
+            0.136, 0.317
+        ],
+        "error": null
     },
     "file618": {
         "data": [
@@ -10345,14 +11131,15 @@
         "lower_extreme": null,
         "upper_specification": 30.015,
         "lower_specification": 30.003,
-        "cp_point": 1.2253281482726308,
-        "cpk_point": 1.0935948041490131,
+        "cp_point": 1.225,
+        "cpk_point": 1.094,
         "cp_interval": [
-            1.1569702405127866, 1.2941557662966972
+            1.157, 1.294
         ],
         "cpk_interval": [
-            1.0250793422250184, 1.1609590271561796
-        ]
+            1.025, 1.161
+        ],
+        "error": null
     },
     "file619": {
         "data": [
@@ -10362,14 +11149,15 @@
         "lower_extreme": null,
         "upper_specification": 31.0,
         "lower_specification": 30.99,
-        "cp_point": 1.2487526908055833,
-        "cpk_point": 1.2323548344076003,
+        "cp_point": 1.249,
+        "cpk_point": 1.232,
         "cp_interval": [
-            1.1631782236785022, 1.3240347283370861
+            1.163, 1.324
         ],
         "cpk_interval": [
-            1.1383725620759182, 1.3129892255327031
-        ]
+            1.138, 1.313
+        ],
+        "error": null
     },
     "file620": {
         "data": [
@@ -10379,14 +11167,15 @@
         "lower_extreme": null,
         "upper_specification": 31.0,
         "lower_specification": 30.99,
-        "cp_point": 1.1850565165908546,
-        "cpk_point": 1.0833454396595592,
+        "cp_point": 1.185,
+        "cpk_point": 1.083,
         "cp_interval": [
-            1.1185470164203244, 1.2343489940820127
+            1.119, 1.234
         ],
         "cpk_interval": [
-            0.9959689360619756, 1.1622688834151669
-        ]
+            0.996, 1.162
+        ],
+        "error": null
     },
     "file621": {
         "data": [
@@ -10396,14 +11185,15 @@
         "lower_extreme": null,
         "upper_specification": 33.0,
         "lower_specification": 32.99,
-        "cp_point": 1.2844666830779115,
-        "cpk_point": 1.2061484265475322,
+        "cp_point": 1.284,
+        "cpk_point": 1.206,
         "cp_interval": [
-            1.2159415793999413, 1.3485259213720509
+            1.216, 1.349
         ],
         "cpk_interval": [
-            1.1396114862619569, 1.278822892709457
-        ]
+            1.14, 1.279
+        ],
+        "error": null
     },
     "file622": {
         "data": [
@@ -10413,14 +11203,15 @@
         "lower_extreme": null,
         "upper_specification": 38.0,
         "lower_specification": 37.99,
-        "cp_point": 1.1715266717882613,
-        "cpk_point": 1.1607385587951096,
+        "cp_point": 1.172,
+        "cpk_point": 1.161,
         "cp_interval": [
-            1.1048558472369499, 1.2353594429146684
+            1.105, 1.235
         ],
         "cpk_interval": [
-            1.0937414387034345, 1.2210534885924098
-        ]
+            1.094, 1.221
+        ],
+        "error": null
     },
     "file623": {
         "data": [
@@ -10430,14 +11221,15 @@
         "lower_extreme": null,
         "upper_specification": 38.0,
         "lower_specification": 37.99,
-        "cp_point": 1.2145046176904393,
-        "cpk_point": 1.1960125338939285,
+        "cp_point": 1.215,
+        "cpk_point": 1.196,
         "cp_interval": [
-            1.1337673705891917, 1.281594801812729
+            1.134, 1.282
         ],
         "cpk_interval": [
-            1.111696107782175, 1.2650314387867756
-        ]
+            1.112, 1.265
+        ],
+        "error": null
     },
     "file624": {
         "data": [
@@ -10447,14 +11239,15 @@
         "lower_extreme": null,
         "upper_specification": 31.0,
         "lower_specification": 30.99,
-        "cp_point": 1.1763118498760303,
-        "cpk_point": 1.1505802725210912,
+        "cp_point": 1.176,
+        "cpk_point": 1.151,
         "cp_interval": [
-            1.1078903631338322, 1.2409969185961358
+            1.108, 1.241
         ],
         "cpk_interval": [
-            1.0877916845428186, 1.2099851082299304
-        ]
+            1.088, 1.21
+        ],
+        "error": null
     },
     "file625": {
         "data": [
@@ -10464,14 +11257,15 @@
         "lower_extreme": null,
         "upper_specification": 31.0,
         "lower_specification": 30.99,
-        "cp_point": 1.1483413869479973,
-        "cpk_point": 1.0951537368284252,
+        "cp_point": 1.148,
+        "cpk_point": 1.095,
         "cp_interval": [
-            1.0862076803204133, 1.2099771904521817
+            1.086, 1.21
         ],
         "cpk_interval": [
-            1.0267434681025382, 1.1652669723554883
-        ]
+            1.027, 1.165
+        ],
+        "error": null
     },
     "file626": {
         "data": [
@@ -10481,14 +11275,15 @@
         "lower_extreme": null,
         "upper_specification": 42.5,
         "lower_specification": 42.49,
-        "cp_point": 1.1384387150026463,
-        "cpk_point": 1.0427595221697885,
+        "cp_point": 1.138,
+        "cpk_point": 1.043,
         "cp_interval": [
-            1.056637610093842, 1.2073773970646915
+            1.057, 1.207
         ],
         "cpk_interval": [
-            0.9441468147837475, 1.1215986994211573
-        ]
+            0.944, 1.122
+        ],
+        "error": null
     },
     "file627": {
         "data": [
@@ -10498,14 +11293,15 @@
         "lower_extreme": null,
         "upper_specification": 42.5,
         "lower_specification": 42.49,
-        "cp_point": 1.1593373583117708,
-        "cpk_point": 1.0734755717080435,
+        "cp_point": 1.159,
+        "cpk_point": 1.073,
         "cp_interval": [
-            1.0658923192859864, 1.2250684885396077
+            1.066, 1.225
         ],
         "cpk_interval": [
-            0.9704984634389116, 1.1456481280374453
-        ]
+            0.97, 1.146
+        ],
+        "error": null
     },
     "file628": {
         "data": [
@@ -10515,14 +11311,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 0.5094512726453788,
-        "cpk_point": 0.4126644407082363,
+        "cp_point": 0.534,
+        "cpk_point": 0.413,
         "cp_interval": [
-            0.21814992835971356, 0.8706798121445255
+            0.229, 0.913
         ],
         "cpk_interval": [
-            0.16378504883868056, 0.831743973718941
-        ]
+            0.164, 0.832
+        ],
+        "error": null
     },
     "file629": {
         "data": [
@@ -10532,14 +11329,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 0.5068954386993951,
-        "cpk_point": 0.4210612113523287,
+        "cp_point": 0.528,
+        "cpk_point": 0.421,
         "cp_interval": [
-            0.2760619799054281, 0.9057996119251449
+            0.288, 0.944
         ],
         "cpk_interval": [
-            0.21236408624548173, 0.878538863781144
-        ]
+            0.212, 0.879
+        ],
+        "error": null
     },
     "file630": {
         "data": [
@@ -10549,14 +11347,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 1.489579584616082,
-        "cpk_point": 0.9156478252139832,
+        "cp_point": 1.532,
+        "cpk_point": 1.748,
         "cp_interval": [
-            1.3449416566482746, 1.6585063614250442
+            1.383, 1.706
         ],
         "cpk_interval": [
-            0.8966109439008416, 0.9384645004065865
-        ]
+            1.524, 2.024
+        ],
+        "error": null
     },
     "file631": {
         "data": [
@@ -10566,14 +11365,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 2.013216020008989,
-        "cpk_point": 0.7716008101692748,
+        "cp_point": 2.066,
+        "cpk_point": 2.249,
         "cp_interval": [
-            1.5420054411194841, 2.291746318459164
+            1.582, 2.352
         ],
         "cpk_interval": [
-            0.7070724918519146, 0.8969893883259674
-        ]
+            1.661, 2.623
+        ],
+        "error": null
     },
     "file632": {
         "data": [
@@ -10583,14 +11383,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 1.7403575758658498,
-        "cpk_point": 0.9272830534669347,
+        "cp_point": 1.754,
+        "cpk_point": 1.817,
         "cp_interval": [
-            0.9400000034770084, 2.577661097735939
+            0.947, 2.597
         ],
         "cpk_interval": [
-            0.8802349165995899, 0.9884128156724361
-        ]
+            0.942, 2.797
+        ],
+        "error": null
     },
     "file633": {
         "data": [
@@ -10600,14 +11401,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 3.3875355783826144,
-        "cpk_point": 0.9119720256999068,
+        "cp_point": 3.411,
+        "cpk_point": 3.933,
         "cp_interval": [
-            2.759604247834523, 3.9423097106610943
+            2.779, 3.969
         ],
         "cpk_interval": [
-            0.8787080300297376, 0.967673215753398
-        ]
+            3.081, 4.744
+        ],
+        "error": null
     },
     "file634": {
         "data": [
@@ -10617,14 +11419,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 2.7177495882888465,
-        "cpk_point": 0.9644873766557702,
+        "cp_point": 2.736,
+        "cpk_point": 3.273,
         "cp_interval": [
-            2.3791727743614937, 3.1110842179046525
+            2.396, 3.132
         ],
         "cpk_interval": [
-            0.9481282783701683, 0.9849436226788475
-        ]
+            2.774, 3.892
+        ],
+        "error": null
     },
     "file635": {
         "data": [
@@ -10634,14 +11437,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 20.0,
         "lower_specification": null,
-        "cp_point": 0.6674829906619659,
-        "cpk_point": 0.6113650250605269,
+        "cp_point": 0.726,
+        "cpk_point": 0.611,
         "cp_interval": [
-            0.34021123483074056, 0.8096673030758061
+            0.37, 0.88
         ],
         "cpk_interval": [
-            0.2781227542196116, 0.7713076859013515
-        ]
+            0.278, 0.781
+        ],
+        "error": null
     },
     "file636": {
         "data": [
@@ -10651,14 +11455,15 @@
         "lower_extreme": null,
         "upper_specification": 41.94,
         "lower_specification": 41.67,
-        "cp_point": 1.3750058489104602,
-        "cpk_point": 1.1895714512501478,
+        "cp_point": 1.375,
+        "cpk_point": 1.19,
         "cp_interval": [
-            1.2359178700081233, 1.4968100274662444
+            1.236, 1.497
         ],
         "cpk_interval": [
-            1.0544859621893283, 1.2986843546148699
-        ]
+            1.054, 1.299
+        ],
+        "error": null
     },
     "file637": {
         "data": [
@@ -10668,14 +11473,15 @@
         "lower_extreme": null,
         "upper_specification": 53.0,
         "lower_specification": 52.85,
-        "cp_point": 0.9182157330663577,
-        "cpk_point": 0.5374177825394727,
+        "cp_point": 0.918,
+        "cpk_point": 0.537,
         "cp_interval": [
-            0.8305378062409368, 0.9948054000822881
+            0.831, 0.995
         ],
         "cpk_interval": [
-            0.4704367951879408, 0.5922210619223092
-        ]
+            0.47, 0.592
+        ],
+        "error": null
     },
     "file638": {
         "data": [
@@ -10685,14 +11491,15 @@
         "lower_extreme": null,
         "upper_specification": 50.122,
         "lower_specification": 50.077,
-        "cp_point": 0.33779955552108687,
-        "cpk_point": 0.27318490840160914,
+        "cp_point": 0.338,
+        "cpk_point": 0.273,
         "cp_interval": [
-            0.24897940377708477, 0.3809414772586869
+            0.249, 0.381
         ],
         "cpk_interval": [
-            0.18339905273681065, 0.32115996959802967
-        ]
+            0.183, 0.321
+        ],
+        "error": null
     },
     "file639": {
         "data": [
@@ -10702,14 +11509,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": -5.0,
-        "cp_point": 1.145594156752724,
-        "cpk_point": 1.1105252563787307,
+        "cp_point": 1.146,
+        "cpk_point": 1.111,
         "cp_interval": [
-            1.047016611616067, 1.2541713418950913
+            1.047, 1.254
         ],
         "cpk_interval": [
-            1.0234228678277755, 1.2138993388445851
-        ]
+            1.023, 1.214
+        ],
+        "error": null
     },
     "file640": {
         "data": [
@@ -10719,14 +11527,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": -5.0,
-        "cp_point": 1.2746804091355841,
-        "cpk_point": 0.9520500476299854,
+        "cp_point": 1.275,
+        "cpk_point": 0.952,
         "cp_interval": [
-            1.1603238553481472, 1.379220034710799
+            1.16, 1.379
         ],
         "cpk_interval": [
-            0.8679266185802204, 1.043483418962892
-        ]
+            0.868, 1.043
+        ],
+        "error": null
     },
     "file641": {
         "data": [
@@ -10736,14 +11545,15 @@
         "lower_extreme": null,
         "upper_specification": -21.0,
         "lower_specification": -39.0,
-        "cp_point": 1.3673045852985437,
-        "cpk_point": 0.730912960274051,
+        "cp_point": 1.367,
+        "cpk_point": 0.731,
         "cp_interval": [
-            1.2373931783995775, 1.505199572129641
+            1.237, 1.505
         ],
         "cpk_interval": [
-            0.637789812899251, 0.8287245692400566
-        ]
+            0.638, 0.829
+        ],
+        "error": null
     },
     "file642": {
         "data": [
@@ -10753,14 +11563,15 @@
         "lower_extreme": null,
         "upper_specification": 9.0,
         "lower_specification": -9.0,
-        "cp_point": 1.5279679624276332,
-        "cpk_point": 1.500896168465561,
+        "cp_point": 1.528,
+        "cpk_point": 1.501,
         "cp_interval": [
-            1.3902920638728131, 1.6567192620833424
+            1.39, 1.657
         ],
         "cpk_interval": [
-            1.356670750420715, 1.632813231786297
-        ]
+            1.357, 1.633
+        ],
+        "error": null
     },
     "file643": {
         "data": [
@@ -10770,14 +11581,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.4848939151033962,
-        "cpk_point": 0.1541584049578522,
+        "cp_point": 0.996,
+        "cpk_point": 0.154,
         "cp_interval": [
-            0.3844030428339342, 0.5482161835288462
+            0.79, 1.126
         ],
         "cpk_interval": [
-            0.08519382011035014, 0.21697043571090305
-        ]
+            0.085, 0.217
+        ],
+        "error": null
     },
     "file644": {
         "data": [
@@ -10787,14 +11599,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.6193074032088252,
-        "cpk_point": 0.540879455595887,
+        "cp_point": 0.75,
+        "cpk_point": 0.541,
         "cp_interval": [
-            0.42076405026239927, 0.6923072369615269
+            0.509, 0.838
         ],
         "cpk_interval": [
-            0.3289797995193779, 0.6243140532597158
-        ]
+            0.329, 0.624
+        ],
+        "error": null
     },
     "file645": {
         "data": [
@@ -10804,14 +11617,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.7406935226877013,
-        "cpk_point": 0.7258948815251226,
+        "cp_point": 0.831,
+        "cpk_point": 0.726,
         "cp_interval": [
-            0.3145574855843645, 1.3807661037565304
+            0.353, 1.548
         ],
         "cpk_interval": [
-            0.2560783633806613, 0.8127568000719562
-        ]
+            0.256, 1.912
+        ],
+        "error": null
     },
     "file646": {
         "data": [
@@ -10821,14 +11635,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.3298949443318095,
-        "cpk_point": 0.8763380068829497,
+        "cp_point": 1.501,
+        "cpk_point": 1.721,
         "cp_interval": [
-            1.1476836693969032, 1.4726672259865592
+            1.295, 1.662
         ],
         "cpk_interval": [
-            0.7957245896074816, 0.9198794529540661
-        ]
+            1.384, 2.036
+        ],
+        "error": null
     },
     "file647": {
         "data": [
@@ -10838,14 +11653,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.078373928427862,
-        "cpk_point": 0.8842137778412452,
+        "cp_point": 1.211,
+        "cpk_point": 1.194,
         "cp_interval": [
-            0.9894502132442257, 1.162980933428202
+            1.112, 1.306
         ],
         "cpk_interval": [
-            0.824764533149438, 0.9234912768811946
-        ]
+            1.068, 1.321
+        ],
+        "error": null
     },
     "file648": {
         "data": [
@@ -10855,14 +11671,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.9700749945827595,
-        "cpk_point": 0.8362948814409991,
+        "cp_point": 1.084,
+        "cpk_point": 1.039,
         "cp_interval": [
-            0.8871348935079404, 1.052929411664764
+            0.992, 1.177
         ],
         "cpk_interval": [
-            0.7837736574929001, 0.8872574563013931
-        ]
+            0.923, 1.158
+        ],
+        "error": null
     },
     "file649": {
         "data": [
@@ -10872,14 +11689,15 @@
         "lower_extreme": null,
         "upper_specification": -21.0,
         "lower_specification": -39.0,
-        "cp_point": 0.8049339732992418,
-        "cpk_point": 0.6569727494030259,
+        "cp_point": 0.805,
+        "cpk_point": 0.657,
         "cp_interval": [
-            0.7157336593243373, 0.8883120545221744
+            0.716, 0.888
         ],
         "cpk_interval": [
-            0.5719038433124615, 0.7253816753152185
-        ]
+            0.572, 0.725
+        ],
+        "error": null
     },
     "file650": {
         "data": [
@@ -10889,14 +11707,15 @@
         "lower_extreme": null,
         "upper_specification": -21.0,
         "lower_specification": -39.0,
-        "cp_point": 0.7202887616933483,
-        "cpk_point": 0.2619759921920415,
+        "cp_point": 0.72,
+        "cpk_point": 0.262,
         "cp_interval": [
-            0.6315487129314038, 0.7980577012280182
+            0.632, 0.798
         ],
         "cpk_interval": [
-            0.2000211169377913, 0.3096571387927095
-        ]
+            0.2, 0.31
+        ],
+        "error": null
     },
     "file651": {
         "data": [
@@ -10906,14 +11725,15 @@
         "lower_extreme": null,
         "upper_specification": 9.0,
         "lower_specification": -9.0,
-        "cp_point": 0.9607774169748712,
-        "cpk_point": 0.8377965558418939,
+        "cp_point": 0.961,
+        "cpk_point": 0.838,
         "cp_interval": [
-            0.8670771380630087, 1.0426865556416292
+            0.867, 1.043
         ],
         "cpk_interval": [
-            0.7154678211376941, 0.9467316262549895
-        ]
+            0.715, 0.947
+        ],
+        "error": null
     },
     "file652": {
         "data": [
@@ -10923,14 +11743,15 @@
         "lower_extreme": null,
         "upper_specification": 9.0,
         "lower_specification": -9.0,
-        "cp_point": 0.7955338918875391,
-        "cpk_point": 0.39825671390805756,
+        "cp_point": 0.796,
+        "cpk_point": 0.398,
         "cp_interval": [
-            0.6721308307826172, 0.8620134074384235
+            0.672, 0.862
         ],
         "cpk_interval": [
-            0.2872565122697374, 0.46840428503571413
-        ]
+            0.287, 0.468
+        ],
+        "error": null
     },
     "file653": {
         "data": [
@@ -10940,14 +11761,15 @@
         "lower_extreme": null,
         "upper_specification": 10.0,
         "lower_specification": 2.0,
-        "cp_point": 1.6536996211270145,
-        "cpk_point": 1.2261896370911927,
+        "cp_point": 1.654,
+        "cpk_point": 1.226,
         "cp_interval": [
-            1.4955692798472089, 1.7914390678849657
+            1.496, 1.791
         ],
         "cpk_interval": [
-            1.0948961572767568, 1.3336625423576636
-        ]
+            1.095, 1.334
+        ],
+        "error": null
     },
     "file654": {
         "data": [
@@ -10957,14 +11779,15 @@
         "lower_extreme": null,
         "upper_specification": 10.0,
         "lower_specification": 2.0,
-        "cp_point": 1.9371513735187345,
-        "cpk_point": 1.0291059089126657,
+        "cp_point": 1.937,
+        "cpk_point": 1.029,
         "cp_interval": [
-            1.7790489007109342, 2.125165379122263
+            1.779, 2.125
         ],
         "cpk_interval": [
-            0.9414800553895589, 1.1180623520091326
-        ]
+            0.941, 1.118
+        ],
+        "error": null
     },
     "file655": {
         "data": [
@@ -10974,14 +11797,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.364251642196179,
-        "cpk_point": 0.16950706332323456,
+        "cp_point": 1.364,
+        "cpk_point": 0.17,
         "cp_interval": [
-            0.6199827049072896, 1.6248139038676075
+            0.62, 1.625
         ],
         "cpk_interval": [
-            0.07847525205769114, 0.2787647457716995
-        ]
+            0.078, 0.279
+        ],
+        "error": null
     },
     "file656": {
         "data": [
@@ -10991,14 +11815,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.7115986595700616,
-        "cpk_point": 1.4577263919412615,
+        "cp_point": 1.712,
+        "cpk_point": 1.458,
         "cp_interval": [
-            1.5727248678771328, 1.7989814343248944
+            1.573, 1.799
         ],
         "cpk_interval": [
-            1.3114006894173005, 1.5471872363142778
-        ]
+            1.311, 1.547
+        ],
+        "error": null
     },
     "file657": {
         "data": [
@@ -11008,14 +11833,15 @@
         "lower_extreme": null,
         "upper_specification": 14.0,
         "lower_specification": 6.0,
-        "cp_point": 2.266108674664454,
-        "cpk_point": 2.05660132746513,
+        "cp_point": 2.266,
+        "cpk_point": 2.057,
         "cp_interval": [
-            2.0280720229534928, 2.473743964500421
+            2.028, 2.474
         ],
         "cpk_interval": [
-            1.676001194086165, 2.3288310261798957
-        ]
+            1.676, 2.329
+        ],
+        "error": null
     },
     "file658": {
         "data": [
@@ -11025,14 +11851,15 @@
         "lower_extreme": null,
         "upper_specification": 14.0,
         "lower_specification": 6.0,
-        "cp_point": 2.943540116082127,
-        "cpk_point": 2.7345099369614294,
+        "cp_point": 2.944,
+        "cpk_point": 2.735,
         "cp_interval": [
-            2.648907403459417, 3.1674719331036307
+            2.649, 3.167
         ],
         "cpk_interval": [
-            2.386154474766033, 3.01847543120278
-        ]
+            2.386, 3.018
+        ],
+        "error": null
     },
     "file659": {
         "data": [
@@ -11042,14 +11869,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 11.0,
         "lower_specification": null,
-        "cp_point": 0.7307098970073751,
-        "cpk_point": 0.681116248706333,
+        "cp_point": 0.864,
+        "cpk_point": 0.681,
         "cp_interval": [
-            0.6462053223512242, 0.8151308076353475
+            0.764, 0.964
         ],
         "cpk_interval": [
-            0.5851807353024561, 0.7909133929180158
-        ]
+            0.585, 0.791
+        ],
+        "error": null
     },
     "file660": {
         "data": [
@@ -11059,14 +11887,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 11.0,
         "lower_specification": null,
-        "cp_point": 0.855037786981923,
-        "cpk_point": 0.8356900482804067,
+        "cp_point": 0.95,
+        "cpk_point": 0.836,
         "cp_interval": [
-            0.7734623070778867, 0.934055278182608
+            0.859, 1.038
         ],
         "cpk_interval": [
-            0.7354522480804561, 0.9182804484254051
-        ]
+            0.735, 0.948
+        ],
+        "error": null
     },
     "file661": {
         "data": [
@@ -11076,14 +11905,15 @@
         "lower_extreme": null,
         "upper_specification": 27.925,
         "lower_specification": 27.905,
-        "cp_point": 1.170153752587267,
-        "cpk_point": 1.07193683381388,
+        "cp_point": 1.17,
+        "cpk_point": 1.072,
         "cp_interval": [
-            1.119261349028992, 1.2155045493447427
+            1.119, 1.216
         ],
         "cpk_interval": [
-            0.9911226854479441, 1.1490844803399578
-        ]
+            0.991, 1.149
+        ],
+        "error": null
     },
     "file662": {
         "data": [
@@ -11093,14 +11923,15 @@
         "lower_extreme": null,
         "upper_specification": 27.925,
         "lower_specification": 27.905,
-        "cp_point": 1.0805873987247827,
-        "cpk_point": 1.0737046056220698,
+        "cp_point": 1.081,
+        "cpk_point": 1.074,
         "cp_interval": [
-            1.0158719915548835, 1.1336648083614087
+            1.016, 1.134
         ],
         "cpk_interval": [
-            0.9886951528965169, 1.118171732624108
-        ]
+            0.989, 1.118
+        ],
+        "error": null
     },
     "file663": {
         "data": [
@@ -11110,14 +11941,15 @@
         "lower_extreme": null,
         "upper_specification": 27.925,
         "lower_specification": 27.905,
-        "cp_point": 1.1487528879741924,
-        "cpk_point": 0.9483799912350918,
+        "cp_point": 1.149,
+        "cpk_point": 0.948,
         "cp_interval": [
-            1.0814829460249231, 1.2025618254597976
+            1.081, 1.203
         ],
         "cpk_interval": [
-            0.8469245017022102, 1.0463201232865225
-        ]
+            0.847, 1.046
+        ],
+        "error": null
     },
     "file664": {
         "data": [
@@ -11127,14 +11959,15 @@
         "lower_extreme": null,
         "upper_specification": 0.016,
         "lower_specification": 0.002,
-        "cp_point": 0.8181632512893582,
-        "cpk_point": 0.22750987129694708,
+        "cp_point": 0.818,
+        "cpk_point": 0.228,
         "cp_interval": [
-            0.7060861422196489, 0.9203317126301976
+            0.706, 0.92
         ],
         "cpk_interval": [
-            0.13132326384222343, 0.3198340172751769
-        ]
+            0.131, 0.32
+        ],
+        "error": null
     },
     "file665": {
         "data": [
@@ -11144,14 +11977,15 @@
         "lower_extreme": null,
         "upper_specification": 27.946,
         "lower_specification": 27.891,
-        "cp_point": 1.4579577114721038,
-        "cpk_point": 0.540052268873573,
+        "cp_point": 1.458,
+        "cpk_point": 0.54,
         "cp_interval": [
-            0.8386053866276275, 1.878127657698184
+            0.839, 1.878
         ],
         "cpk_interval": [
-            0.2226647044368992, 0.843300023978569
-        ]
+            0.223, 0.843
+        ],
+        "error": null
     },
     "file666": {
         "data": [
@@ -11161,14 +11995,15 @@
         "lower_extreme": null,
         "upper_specification": 27.946,
         "lower_specification": 27.891,
-        "cp_point": 1.3175605412692744,
-        "cpk_point": 0.4829438950762846,
+        "cp_point": 1.318,
+        "cpk_point": 0.483,
         "cp_interval": [
-            0.7106053843088519, 1.8598469887856421
+            0.711, 1.86
         ],
         "cpk_interval": [
-            0.21302272988061258, 0.7749851538504032
-        ]
+            0.213, 0.775
+        ],
+        "error": null
     },
     "file667": {
         "data": [
@@ -11178,14 +12013,15 @@
         "lower_extreme": null,
         "upper_specification": 27.946,
         "lower_specification": 27.891,
-        "cp_point": 1.6341044146835595,
-        "cpk_point": 0.6886355988239721,
+        "cp_point": 1.634,
+        "cpk_point": 0.689,
         "cp_interval": [
-            0.9299625482844625, 1.9359791008955918
+            0.93, 1.936
         ],
         "cpk_interval": [
-            0.34877795014005664, 0.9637515605528945
-        ]
+            0.349, 0.964
+        ],
+        "error": null
     },
     "file668": {
         "data": [
@@ -11195,14 +12031,15 @@
         "lower_extreme": null,
         "upper_specification": 27.946,
         "lower_specification": 27.891,
-        "cp_point": 1.3544872242841557,
-        "cpk_point": 0.5627054947702093,
+        "cp_point": 1.354,
+        "cpk_point": 0.563,
         "cp_interval": [
-            0.719863993562847, 1.8619456992895635
+            0.72, 1.862
         ],
         "cpk_interval": [
-            0.2848338174054207, 0.820514859597645
-        ]
+            0.285, 0.821
+        ],
+        "error": null
     },
     "file669": {
         "data": [
@@ -11212,14 +12049,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.05,
         "lower_specification": null,
-        "cp_point": 0.3245003316000569,
-        "cpk_point": 0.28033415843355536,
+        "cp_point": 0.326,
+        "cpk_point": 0.28,
         "cp_interval": [
-            0.008252082054082685, 0.7401498299570414
+            0.008, 0.744
         ],
         "cpk_interval": [
-            0.0066644048641873775, 0.7099568169517794
-        ]
+            0.007, 0.71
+        ],
+        "error": null
     },
     "file670": {
         "data": [
@@ -11229,14 +12067,15 @@
         "lower_extreme": null,
         "upper_specification": 27.925,
         "lower_specification": 27.905,
-        "cp_point": 1.2319689642239424,
-        "cpk_point": 1.2026595354115357,
+        "cp_point": 1.232,
+        "cpk_point": 1.203,
         "cp_interval": [
-            1.1735932353467435, 1.273963226260765
+            1.174, 1.274
         ],
         "cpk_interval": [
-            1.127672510444981, 1.254822883342434
-        ]
+            1.128, 1.255
+        ],
+        "error": null
     },
     "file671": {
         "data": [
@@ -11246,14 +12085,15 @@
         "lower_extreme": null,
         "upper_specification": 30.015,
         "lower_specification": 30.003,
-        "cp_point": 1.3477036197396912,
-        "cpk_point": 1.2822082351188842,
+        "cp_point": 1.348,
+        "cpk_point": 1.282,
         "cp_interval": [
-            1.269633542834367, 1.4218523605801663
+            1.27, 1.422
         ],
         "cpk_interval": [
-            1.2092276928113732, 1.3502634310776167
-        ]
+            1.209, 1.35
+        ],
+        "error": null
     },
     "file672": {
         "data": [
@@ -11263,14 +12103,15 @@
         "lower_extreme": null,
         "upper_specification": 31.0,
         "lower_specification": 30.99,
-        "cp_point": 1.2048407615720653,
-        "cpk_point": 1.182952062049338,
+        "cp_point": 1.205,
+        "cpk_point": 1.183,
         "cp_interval": [
-            1.134274111956326, 1.2715894409768989
+            1.134, 1.272
         ],
         "cpk_interval": [
-            1.1175063792943614, 1.2445392847302
-        ]
+            1.118, 1.245
+        ],
+        "error": null
     },
     "file673": {
         "data": [
@@ -11280,14 +12121,15 @@
         "lower_extreme": null,
         "upper_specification": 31.0,
         "lower_specification": 30.99,
-        "cp_point": 1.1189389502144074,
-        "cpk_point": 1.063631060803623,
+        "cp_point": 1.119,
+        "cpk_point": 1.064,
         "cp_interval": [
-            1.053707335800035, 1.1807370337483467
+            1.054, 1.181
         ],
         "cpk_interval": [
-            1.0041953946862665, 1.1201543482664427
-        ]
+            1.004, 1.12
+        ],
+        "error": null
     },
     "file674": {
         "data": [
@@ -11297,14 +12139,15 @@
         "lower_extreme": null,
         "upper_specification": 33.0,
         "lower_specification": 32.99,
-        "cp_point": 1.276392356365072,
-        "cpk_point": 1.207195321073499,
+        "cp_point": 1.276,
+        "cpk_point": 1.207,
         "cp_interval": [
-            1.1932374983416147, 1.357869724059439
+            1.193, 1.358
         ],
         "cpk_interval": [
-            1.1139186609392395, 1.2963454452411485
-        ]
+            1.114, 1.296
+        ],
+        "error": null
     },
     "file675": {
         "data": [
@@ -11314,14 +12157,15 @@
         "lower_extreme": null,
         "upper_specification": 38.0,
         "lower_specification": 37.99,
-        "cp_point": 1.2465016364066144,
-        "cpk_point": 1.184305624658823,
+        "cp_point": 1.247,
+        "cpk_point": 1.184,
         "cp_interval": [
-            1.1739645811379233, 1.3138991805867013
+            1.174, 1.314
         ],
         "cpk_interval": [
-            1.1100912487680445, 1.2551190135459933
-        ]
+            1.11, 1.255
+        ],
+        "error": null
     },
     "file676": {
         "data": [
@@ -11331,14 +12175,15 @@
         "lower_extreme": null,
         "upper_specification": 38.0,
         "lower_specification": 37.99,
-        "cp_point": 1.1442075726678678,
-        "cpk_point": 1.1342949305524097,
+        "cp_point": 1.144,
+        "cpk_point": 1.134,
         "cp_interval": [
-            1.0762609370417113, 1.2038646409680065
+            1.076, 1.204
         ],
         "cpk_interval": [
-            1.021943747597295, 1.1909654408269348
-        ]
+            1.022, 1.191
+        ],
+        "error": null
     },
     "file677": {
         "data": [
@@ -11348,14 +12193,15 @@
         "lower_extreme": null,
         "upper_specification": 31.0,
         "lower_specification": 30.99,
-        "cp_point": 1.2416456332038024,
-        "cpk_point": 1.2017325036923863,
+        "cp_point": 1.242,
+        "cpk_point": 1.202,
         "cp_interval": [
-            1.1732715211233087, 1.3143152514194627
+            1.173, 1.314
         ],
         "cpk_interval": [
-            1.131988780319145, 1.2770967113443557
-        ]
+            1.132, 1.277
+        ],
+        "error": null
     },
     "file678": {
         "data": [
@@ -11365,14 +12211,15 @@
         "lower_extreme": null,
         "upper_specification": 31.0,
         "lower_specification": 30.99,
-        "cp_point": 1.2950262781822452,
-        "cpk_point": 1.192382542555293,
+        "cp_point": 1.295,
+        "cpk_point": 1.192,
         "cp_interval": [
-            1.2014632444862698, 1.3827982244039994
+            1.201, 1.383
         ],
         "cpk_interval": [
-            1.1186582154835243, 1.2596666244883032
-        ]
+            1.119, 1.26
+        ],
+        "error": null
     },
     "file679": {
         "data": [
@@ -11382,14 +12229,15 @@
         "lower_extreme": null,
         "upper_specification": 42.5,
         "lower_specification": 42.49,
-        "cp_point": 1.2747272742053546,
-        "cpk_point": 1.2070075992413614,
+        "cp_point": 1.275,
+        "cpk_point": 1.207,
         "cp_interval": [
-            1.2080547399485586, 1.343065523859332
+            1.208, 1.343
         ],
         "cpk_interval": [
-            1.1360864674494382, 1.2737069899876692
-        ]
+            1.136, 1.274
+        ],
+        "error": null
     },
     "file680": {
         "data": [
@@ -11399,14 +12247,15 @@
         "lower_extreme": null,
         "upper_specification": 42.5,
         "lower_specification": 42.49,
-        "cp_point": 1.2227446864037728,
-        "cpk_point": 1.1657190221525717,
+        "cp_point": 1.223,
+        "cpk_point": 1.166,
         "cp_interval": [
-            1.1536055111103647, 1.292949359201963
+            1.154, 1.293
         ],
         "cpk_interval": [
-            1.0825257157327988, 1.2561323242376978
-        ]
+            1.083, 1.256
+        ],
+        "error": null
     },
     "file681": {
         "data": [
@@ -11416,14 +12265,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 0.78029194444701,
-        "cpk_point": 0.7479640962983545,
+        "cp_point": 0.854,
+        "cpk_point": 0.748,
         "cp_interval": [
-            0.6966513682918133, 0.8656957477003916
+            0.762, 0.947
         ],
         "cpk_interval": [
-            0.6510361229735423, 0.8585623551771048
-        ]
+            0.651, 0.859
+        ],
+        "error": null
     },
     "file682": {
         "data": [
@@ -11433,14 +12283,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 0.9709708389353243,
-        "cpk_point": 0.8921563588824832,
+        "cp_point": 1.036,
+        "cpk_point": 1.0,
         "cp_interval": [
-            0.8748587683550786, 1.0675326470356377
+            0.933, 1.139
         ],
         "cpk_interval": [
-            0.8514162462960014, 0.929248529305573
-        ]
+            0.875, 1.134
+        ],
+        "error": null
     },
     "file683": {
         "data": [
@@ -11450,14 +12301,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 1.2079924626145295,
-        "cpk_point": 0.9440805170649119,
+        "cp_point": 1.272,
+        "cpk_point": 1.284,
         "cp_interval": [
-            1.068501853619226, 1.3518403286532434
+            1.125, 1.423
         ],
         "cpk_interval": [
-            0.9080576767444477, 0.9718990308622919
-        ]
+            1.108, 1.473
+        ],
+        "error": null
     },
     "file684": {
         "data": [
@@ -11467,14 +12319,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 4.575372318125812,
-        "cpk_point": 0.8964210886826723,
+        "cp_point": 4.702,
+        "cpk_point": 6.542,
         "cp_interval": [
-            4.072471084660076, 5.033853334886406
+            4.185, 5.173
         ],
         "cpk_interval": [
-            0.8465375135167713, 0.9268559087907018
-        ]
+            5.603, 7.496
+        ],
+        "error": null
     },
     "file685": {
         "data": [
@@ -11484,14 +12337,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 5.219146653207433,
-        "cpk_point": 0.6248616671631828,
+        "cp_point": 5.354,
+        "cpk_point": 6.728,
         "cp_interval": [
-            3.9456363577270324, 6.183075245504122
+            4.048, 6.343
         ],
         "cpk_interval": [
-            0.5138411719856544, 0.7999076075315036
-        ]
+            4.909, 7.969
+        ],
+        "error": null
     },
     "file686": {
         "data": [
@@ -11501,14 +12355,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 3.505690856285265,
-        "cpk_point": 0.7276289248893497,
+        "cp_point": 3.573,
+        "cpk_point": 4.07,
         "cp_interval": [
-            2.5932402213825947, 4.3362813300282905
+            2.643, 4.419
         ],
         "cpk_interval": [
-            0.6484910067868397, 0.9273279888267933
-        ]
+            2.853, 5.229
+        ],
+        "error": null
     },
     "file687": {
         "data": [
@@ -11518,14 +12373,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 2.639746168146615,
-        "cpk_point": 0.8305998680721987,
+        "cp_point": 2.709,
+        "cpk_point": 3.132,
         "cp_interval": [
-            2.109903426281183, 2.966772686422459
+            2.165, 3.045
         ],
         "cpk_interval": [
-            0.7960363026696401, 0.8678098854780533
-        ]
+            2.39, 3.601
+        ],
+        "error": null
     },
     "file688": {
         "data": [
@@ -11535,14 +12391,15 @@
         "lower_extreme": null,
         "upper_specification": 30.015,
         "lower_specification": 30.003,
-        "cp_point": 1.434549446486147,
-        "cpk_point": 1.4132034938246594,
+        "cp_point": 1.435,
+        "cpk_point": 1.413,
         "cp_interval": [
-            1.3523425745405109, 1.5127524391106562
+            1.352, 1.513
         ],
         "cpk_interval": [
-            1.3305956392587681, 1.4903859155514712
-        ]
+            1.331, 1.49
+        ],
+        "error": null
     },
     "file689": {
         "data": [
@@ -11552,14 +12409,15 @@
         "lower_extreme": null,
         "upper_specification": 31.0,
         "lower_specification": 30.99,
-        "cp_point": 1.2847163308439349,
-        "cpk_point": 1.1755905486661782,
+        "cp_point": 1.285,
+        "cpk_point": 1.176,
         "cp_interval": [
-            1.215309001894432, 1.360360335498101
+            1.215, 1.36
         ],
         "cpk_interval": [
-            1.1128485130766226, 1.2412000534474181
-        ]
+            1.113, 1.241
+        ],
+        "error": null
     },
     "file690": {
         "data": [
@@ -11569,14 +12427,15 @@
         "lower_extreme": null,
         "upper_specification": 31.0,
         "lower_specification": 30.99,
-        "cp_point": 1.0863712495345366,
-        "cpk_point": 1.0427525438397591,
+        "cp_point": 1.086,
+        "cpk_point": 1.043,
         "cp_interval": [
-            1.023639089115405, 1.1459087497331417
+            1.024, 1.146
         ],
         "cpk_interval": [
-            0.9840208284790959, 1.098643205668695
-        ]
+            0.984, 1.099
+        ],
+        "error": null
     },
     "file691": {
         "data": [
@@ -11586,14 +12445,15 @@
         "lower_extreme": null,
         "upper_specification": 33.0,
         "lower_specification": 32.99,
-        "cp_point": 1.1312150586234901,
-        "cpk_point": 1.105508445944351,
+        "cp_point": 1.131,
+        "cpk_point": 1.106,
         "cp_interval": [
-            1.0571925563067612, 1.192700164844953
+            1.057, 1.193
         ],
         "cpk_interval": [
-            1.02445586094197, 1.1707323596436174
-        ]
+            1.024, 1.171
+        ],
+        "error": null
     },
     "file692": {
         "data": [
@@ -11603,14 +12463,15 @@
         "lower_extreme": null,
         "upper_specification": 38.0,
         "lower_specification": 37.99,
-        "cp_point": 1.4277298701376433,
-        "cpk_point": 1.4259679209175464,
+        "cp_point": 1.428,
+        "cpk_point": 1.426,
         "cp_interval": [
-            1.3372137513942322, 1.479065995940253
+            1.337, 1.479
         ],
         "cpk_interval": [
-            1.3036710077118125, 1.4577419701867094
-        ]
+            1.304, 1.458
+        ],
+        "error": null
     },
     "file693": {
         "data": [
@@ -11620,14 +12481,15 @@
         "lower_extreme": null,
         "upper_specification": 38.0,
         "lower_specification": 37.99,
-        "cp_point": 1.2272023641837495,
-        "cpk_point": 1.2057450794986877,
+        "cp_point": 1.227,
+        "cpk_point": 1.206,
         "cp_interval": [
-            1.1530345071538768, 1.2947507951349482
+            1.153, 1.295
         ],
         "cpk_interval": [
-            1.0902030480522864, 1.2781749073822692
-        ]
+            1.09, 1.278
+        ],
+        "error": null
     },
     "file694": {
         "data": [
@@ -11637,14 +12499,15 @@
         "lower_extreme": null,
         "upper_specification": 31.0,
         "lower_specification": 30.99,
-        "cp_point": 1.3158579599371805,
-        "cpk_point": 1.3111701023518088,
+        "cp_point": 1.316,
+        "cpk_point": 1.311,
         "cp_interval": [
-            1.2459702359160763, 1.3668253007740876
+            1.246, 1.367
         ],
         "cpk_interval": [
-            1.2255127822061005, 1.3562545516189886
-        ]
+            1.226, 1.356
+        ],
+        "error": null
     },
     "file695": {
         "data": [
@@ -11654,14 +12517,15 @@
         "lower_extreme": null,
         "upper_specification": 31.0,
         "lower_specification": 30.99,
-        "cp_point": 1.2498003334887704,
-        "cpk_point": 1.1781189803175312,
+        "cp_point": 1.25,
+        "cpk_point": 1.178,
         "cp_interval": [
-            1.1667621299575994, 1.32034868451942
+            1.167, 1.32
         ],
         "cpk_interval": [
-            1.0913545639189446, 1.255247786684825
-        ]
+            1.091, 1.255
+        ],
+        "error": null
     },
     "file696": {
         "data": [
@@ -11671,14 +12535,15 @@
         "lower_extreme": null,
         "upper_specification": 42.5,
         "lower_specification": 42.49,
-        "cp_point": 1.273414750829385,
-        "cpk_point": 1.2638615303157452,
+        "cp_point": 1.273,
+        "cpk_point": 1.264,
         "cp_interval": [
-            1.2142039111806724, 1.337534617496906
+            1.214, 1.338
         ],
         "cpk_interval": [
-            1.164090958554077, 1.324185543270681
-        ]
+            1.164, 1.324
+        ],
+        "error": null
     },
     "file697": {
         "data": [
@@ -11688,14 +12553,15 @@
         "lower_extreme": null,
         "upper_specification": 42.5,
         "lower_specification": 42.49,
-        "cp_point": 1.3787788885395535,
-        "cpk_point": 1.3271383869845663,
+        "cp_point": 1.379,
+        "cpk_point": 1.327,
         "cp_interval": [
-            1.314025674657789, 1.4446679453067393
+            1.314, 1.445
         ],
         "cpk_interval": [
-            1.230538531715564, 1.4216967304609425
-        ]
+            1.231, 1.422
+        ],
+        "error": null
     },
     "file698": {
         "data": [
@@ -11705,14 +12571,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 1.0130698871002775,
-        "cpk_point": 0.9535011827168509,
+        "cp_point": 1.054,
+        "cpk_point": 1.04,
         "cp_interval": [
-            0.9348284251384493, 1.0874558090032305
+            0.972, 1.131
         ],
         "cpk_interval": [
-            0.9033643978493896, 0.9763524719399153
-        ]
+            0.932, 1.156
+        ],
+        "error": null
     },
     "file699": {
         "data": [
@@ -11722,14 +12589,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 1.1168443243304687,
-        "cpk_point": 0.9630019535078495,
+        "cp_point": 1.162,
+        "cpk_point": 1.205,
         "cp_interval": [
-            1.0142395378194617, 1.2050069832051473
+            1.055, 1.253
         ],
         "cpk_interval": [
-            0.9263798954867332, 0.987814731896412
-        ]
+            1.043, 1.362
+        ],
+        "error": null
     },
     "file700": {
         "data": [
@@ -11739,14 +12607,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 1.3388484632253277,
-        "cpk_point": 0.9804475745016565,
+        "cp_point": 1.356,
+        "cpk_point": 1.488,
         "cp_interval": [
-            1.1721943545544204, 1.5343592032926778
+            1.187, 1.554
         ],
         "cpk_interval": [
-            0.9641677237093124, 1.0017071211324016
-        ]
+            1.248, 1.79
+        ],
+        "error": null
     },
     "file701": {
         "data": [
@@ -11756,14 +12625,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 4.852489272082183,
-        "cpk_point": 0.9214973261981337,
+        "cp_point": 4.987,
+        "cpk_point": 7.136,
         "cp_interval": [
-            4.538891283344645, 5.18027412669235
+            4.665, 5.324
         ],
         "cpk_interval": [
-            0.8695877771816534, 0.9613945006051801
-        ]
+            6.469, 7.823
+        ],
+        "error": null
     },
     "file702": {
         "data": [
@@ -11773,14 +12643,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 4.984451692297244,
-        "cpk_point": 0.911455311786007,
+        "cp_point": 5.019,
+        "cpk_point": 6.436,
         "cp_interval": [
-            4.340968990058736, 5.540746205893056
+            4.371, 5.579
         ],
         "cpk_interval": [
-            0.8775987417142502, 0.9582051702522504
-        ]
+            5.36, 7.47
+        ],
+        "error": null
     },
     "file703": {
         "data": [
@@ -11790,14 +12661,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 4.846026831460017,
-        "cpk_point": 0.9224030392566323,
+        "cp_point": 4.877,
+        "cpk_point": 6.286,
         "cp_interval": [
-            4.27543834870535, 5.3759945002711635
+            4.302, 5.41
         ],
         "cpk_interval": [
-            0.8921563128983813, 0.9674815400860489
-        ]
+            5.353, 7.183
+        ],
+        "error": null
     },
     "file704": {
         "data": [
@@ -11807,14 +12679,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 2.3579216100797393,
-        "cpk_point": 0.964882035011369,
+        "cp_point": 2.372,
+        "cpk_point": 2.75,
         "cp_interval": [
-            2.001793183397219, 2.772220321314768
+            2.013, 2.788
         ],
         "cpk_interval": [
-            0.9518001892307909, 0.9829658484991065
-        ]
+            2.25, 3.367
+        ],
+        "error": null
     },
     "file705": {
         "data": [
@@ -11824,14 +12697,15 @@
         "lower_extreme": null,
         "upper_specification": 71.451,
         "lower_specification": 71.379,
-        "cp_point": 1.0206148846567804,
-        "cpk_point": 1.0134437179984703,
+        "cp_point": 1.021,
+        "cpk_point": 1.013,
         "cp_interval": [
-            0.8517873095516623, 1.1605896574816383
+            0.852, 1.161
         ],
         "cpk_interval": [
-            0.7475618934783873, 1.1157780243883912
-        ]
+            0.748, 1.116
+        ],
+        "error": null
     },
     "file706": {
         "data": [
@@ -11841,14 +12715,15 @@
         "lower_extreme": null,
         "upper_specification": 67.74,
         "lower_specification": 67.68,
-        "cp_point": 1.0206929422005149,
-        "cpk_point": 0.9671816894242627,
+        "cp_point": 1.021,
+        "cpk_point": 0.967,
         "cp_interval": [
-            0.9247313873078122, 1.0971186263164237
+            0.925, 1.097
         ],
         "cpk_interval": [
-            0.8415552056978824, 1.0517644893948497
-        ]
+            0.842, 1.052
+        ],
+        "error": null
     },
     "file707": {
         "data": [
@@ -11858,14 +12733,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.035,
         "lower_specification": null,
-        "cp_point": 0.8250596837025986,
-        "cpk_point": 0.7596035803860192,
+        "cp_point": 0.832,
+        "cpk_point": 0.76,
         "cp_interval": [
-            0.7010902439715536, 0.9148793472483664
+            0.707, 0.923
         ],
         "cpk_interval": [
-            0.6104304361483651, 0.8829592440007484
-        ]
+            0.61, 0.883
+        ],
+        "error": null
     },
     "file708": {
         "data": [
@@ -11875,14 +12751,15 @@
         "lower_extreme": null,
         "upper_specification": 65.202,
         "lower_specification": 65.142,
-        "cp_point": 0.9011515516511517,
-        "cpk_point": 0.8646482560989511,
+        "cp_point": 0.901,
+        "cpk_point": 0.865,
         "cp_interval": [
-            0.7644860739332923, 1.0215338478340115
+            0.764, 1.022
         ],
         "cpk_interval": [
-            0.7542076068280763, 0.9667838994051181
-        ]
+            0.754, 0.967
+        ],
+        "error": null
     },
     "file709": {
         "data": [
@@ -11892,14 +12769,15 @@
         "lower_extreme": null,
         "upper_specification": 74.635,
         "lower_specification": 74.563,
-        "cp_point": 0.874373494428021,
-        "cpk_point": 0.8324183154233628,
+        "cp_point": 0.874,
+        "cpk_point": 0.832,
         "cp_interval": [
-            0.6902532585206896, 1.0638487142640922
+            0.69, 1.064
         ],
         "cpk_interval": [
-            0.6036428333663065, 1.0328109990295191
-        ]
+            0.604, 1.033
+        ],
+        "error": null
     },
     "file710": {
         "data": [
@@ -11909,14 +12787,15 @@
         "lower_extreme": null,
         "upper_specification": 71.451,
         "lower_specification": 71.379,
-        "cp_point": 0.8038234812864136,
-        "cpk_point": 0.7123655917042816,
+        "cp_point": 0.804,
+        "cpk_point": 0.712,
         "cp_interval": [
-            0.6105572359575587, 0.9698231780811196
+            0.611, 0.97
         ],
         "cpk_interval": [
-            0.5090732070530457, 0.901481525057006
-        ]
+            0.509, 0.901
+        ],
+        "error": null
     },
     "file711": {
         "data": [
@@ -11926,14 +12805,15 @@
         "lower_extreme": null,
         "upper_specification": 67.74,
         "lower_specification": 67.68,
-        "cp_point": 1.0312414705100943,
-        "cpk_point": 0.945886394722709,
+        "cp_point": 1.031,
+        "cpk_point": 0.946,
         "cp_interval": [
-            0.9284257679900595, 1.1093713543683217
+            0.928, 1.109
         ],
         "cpk_interval": [
-            0.8301417891937164, 1.0487864089677896
-        ]
+            0.83, 1.049
+        ],
+        "error": null
     },
     "file712": {
         "data": [
@@ -11943,14 +12823,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.035,
         "lower_specification": null,
-        "cp_point": 0.6735886335433743,
-        "cpk_point": 0.5722267478604381,
+        "cp_point": 0.688,
+        "cpk_point": 0.572,
         "cp_interval": [
-            0.608533554417592, 0.749411868442054
+            0.622, 0.766
         ],
         "cpk_interval": [
-            0.48852438058096476, 0.6667683458291374
-        ]
+            0.489, 0.667
+        ],
+        "error": null
     },
     "file713": {
         "data": [
@@ -11960,14 +12841,15 @@
         "lower_extreme": null,
         "upper_specification": 65.202,
         "lower_specification": 65.142,
-        "cp_point": 0.9357832290109568,
-        "cpk_point": 0.8692654397351862,
+        "cp_point": 0.936,
+        "cpk_point": 0.869,
         "cp_interval": [
-            0.8172797076147512, 1.0608299059261055
+            0.817, 1.061
         ],
         "cpk_interval": [
-            0.7127906354227843, 1.006400761440314
-        ]
+            0.713, 1.006
+        ],
+        "error": null
     },
     "file714": {
         "data": [
@@ -11977,14 +12859,15 @@
         "lower_extreme": null,
         "upper_specification": 74.635,
         "lower_specification": 74.563,
-        "cp_point": 1.0761063043649284,
-        "cpk_point": 1.0506047173460134,
+        "cp_point": 1.076,
+        "cpk_point": 1.051,
         "cp_interval": [
-            0.9612266519314062, 1.1758733523159755
+            0.961, 1.176
         ],
         "cpk_interval": [
-            0.910522770073814, 1.1574211908438818
-        ]
+            0.911, 1.157
+        ],
+        "error": null
     },
     "file715": {
         "data": [
@@ -11994,14 +12877,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 50.0,
         "lower_specification": null,
-        "cp_point": 0.5591343057978222,
-        "cpk_point": 0.4294562783968404,
+        "cp_point": 1.165,
+        "cpk_point": 0.429,
         "cp_interval": [
-            0.36674271181728363, 0.7260989975523289
+            0.764, 1.513
         ],
         "cpk_interval": [
-            0.21929731059321728, 0.6341904773330367
-        ]
+            0.219, 0.639
+        ],
+        "error": null
     },
     "file716": {
         "data": [
@@ -12011,14 +12895,15 @@
         "lower_extreme": null,
         "upper_specification": 46.26,
         "lower_specification": 46.05,
-        "cp_point": 7.676287609486799,
-        "cpk_point": 3.70131109312015,
+        "cp_point": 7.676,
+        "cpk_point": 3.701,
         "cp_interval": [
-            4.984278858171286, 9.904050030893012
+            4.984, 9.904
         ],
         "cpk_interval": [
-            2.379485518674071, 4.752412554329285
-        ]
+            2.379, 4.752
+        ],
+        "error": null
     },
     "file717": {
         "data": [
@@ -12028,14 +12913,15 @@
         "lower_extreme": null,
         "upper_specification": 48.0,
         "lower_specification": 47.9,
-        "cp_point": 2.7103299583608997,
-        "cpk_point": 2.172147813486693,
+        "cp_point": 2.71,
+        "cpk_point": 2.172,
         "cp_interval": [
-            1.7564890679285785, 3.499610527621551
+            1.756, 3.5
         ],
         "cpk_interval": [
-            1.367912485564905, 2.805488270060595
-        ]
+            1.368, 2.805
+        ],
+        "error": null
     },
     "file718": {
         "data": [
@@ -12045,14 +12931,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 10.0,
         "lower_specification": null,
-        "cp_point": 2.04425817876204,
-        "cpk_point": 0.6934611739410933,
+        "cp_point": 3.315,
+        "cpk_point": 3.574,
         "cp_interval": [
-            1.3567969570832443, 2.6227971251789266
+            2.2, 4.253
         ],
         "cpk_interval": [
-            0.3717288070667666, 0.9252043282199097
-        ]
+            2.463, 4.506
+        ],
+        "error": null
     },
     "file719": {
         "data": [
@@ -12062,14 +12949,15 @@
         "lower_extreme": null,
         "upper_specification": 49.948,
         "lower_specification": 49.9,
-        "cp_point": 1.8094492631076426,
-        "cpk_point": 0.15718944972001297,
+        "cp_point": 1.809,
+        "cpk_point": 0.157,
         "cp_interval": [
-            1.093542930541378, 2.4010580384177183
+            1.094, 2.401
         ],
         "cpk_interval": [
-            -0.03556003034740356, 0.3249701941445099
-        ]
+            -0.036, 0.325
+        ],
+        "error": null
     },
     "file720": {
         "data": [
@@ -12079,14 +12967,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 10.0,
         "lower_specification": null,
-        "cp_point": 2.095209169036803,
-        "cpk_point": 0.658777146485357,
+        "cp_point": 3.326,
+        "cpk_point": 3.69,
         "cp_interval": [
-            1.3950106249374359, 2.6856827686116445
+            2.214, 4.263
         ],
         "cpk_interval": [
-            0.35125099750861116, 0.8780135183999428
-        ]
+            2.536, 4.664
+        ],
+        "error": null
     },
     "file721": {
         "data": [
@@ -12096,14 +12985,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.1354009579007402,
-        "cpk_point": 0.6611629773861002,
+        "cp_point": 1.817,
+        "cpk_point": 1.749,
         "cp_interval": [
-            0.7703926292307497, 1.4641369442750418
+            1.233, 2.343
         ],
         "cpk_interval": [
-            0.37986072694473527, 0.8860217063442387
-        ]
+            1.193, 2.248
+        ],
+        "error": null
     },
     "file722": {
         "data": [
@@ -12113,14 +13003,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.0317884968699307,
-        "cpk_point": 0.7692878365948049,
+        "cp_point": 1.651,
+        "cpk_point": 1.132,
         "cp_interval": [
-            0.5067428180723538, 1.5232187664741281
+            0.811, 2.437
         ],
         "cpk_interval": [
-            0.43568686556741837, 0.9506323469289363
-        ]
+            0.498, 1.796
+        ],
+        "error": null
     },
     "file723": {
         "data": [
@@ -12130,14 +13021,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 30.0,
         "lower_specification": null,
-        "cp_point": 0.005768272958517949,
-        "cpk_point": -1.1682020728791982,
+        "cp_point": 0.519,
+        "cpk_point": -1.168,
         "cp_interval": [
-            0.00490638394935806, 0.010224353475636017
+            0.442, 0.92
         ],
         "cpk_interval": [
-            -1.6469175038918267, -0.6367666321413232
-        ]
+            -1.647, -0.637
+        ],
+        "error": null
     },
     "file724": {
         "data": [
@@ -12147,14 +13039,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 30.0,
         "lower_specification": null,
-        "cp_point": 0.029961902284581437,
-        "cpk_point": -0.25233901175450535,
+        "cp_point": 0.449,
+        "cpk_point": -0.252,
         "cp_interval": [
-            0.01687775941679902, 0.04169741433440719
+            0.253, 0.625
         ],
         "cpk_interval": [
-            -0.37565757241196346, -0.09799082626789553
-        ]
+            -0.376, -0.098
+        ],
+        "error": null
     },
     "file725": {
         "data": [
@@ -12164,14 +13057,15 @@
         "lower_extreme": null,
         "upper_specification": 42.228,
         "lower_specification": 42.212,
-        "cp_point": 1.0113078624923764,
-        "cpk_point": 0.9408325430556068,
+        "cp_point": 1.011,
+        "cpk_point": 0.941,
         "cp_interval": [
-            0.9184422593869546, 1.0733467053086245
+            0.918, 1.073
         ],
         "cpk_interval": [
-            0.8246555075172013, 1.0307370287039888
-        ]
+            0.825, 1.031
+        ],
+        "error": null
     },
     "file726": {
         "data": [
@@ -12181,14 +13075,15 @@
         "lower_extreme": null,
         "upper_specification": 42.228,
         "lower_specification": 42.212,
-        "cp_point": 1.0823930761046685,
-        "cpk_point": 1.018173611059992,
+        "cp_point": 1.082,
+        "cpk_point": 1.018,
         "cp_interval": [
-            1.0218704254464706, 1.1228717441355887
+            1.022, 1.123
         ],
         "cpk_interval": [
-            0.9344970885306912, 1.085596695311162
-        ]
+            0.934, 1.086
+        ],
+        "error": null
     },
     "file727": {
         "data": [
@@ -12198,14 +13093,15 @@
         "lower_extreme": null,
         "upper_specification": 42.228,
         "lower_specification": 42.212,
-        "cp_point": 1.0080026168881275,
-        "cpk_point": 0.9976709058331561,
+        "cp_point": 1.008,
+        "cpk_point": 0.998,
         "cp_interval": [
-            0.9310825522802898, 1.0668926085836379
+            0.931, 1.067
         ],
         "cpk_interval": [
-            0.8836481726260543, 1.0528857268393343
-        ]
+            0.884, 1.053
+        ],
+        "error": null
     },
     "file728": {
         "data": [
@@ -12215,14 +13111,15 @@
         "lower_extreme": null,
         "upper_specification": 42.228,
         "lower_specification": 42.212,
-        "cp_point": 0.8235410304419853,
-        "cpk_point": 0.8077952793319216,
+        "cp_point": 0.824,
+        "cpk_point": 0.808,
         "cp_interval": [
-            0.7170139915126861, 0.9327413859084794
+            0.717, 0.933
         ],
         "cpk_interval": [
-            0.6840520079857066, 0.9192033000105081
-        ]
+            0.684, 0.919
+        ],
+        "error": null
     },
     "file729": {
         "data": [
@@ -12232,14 +13129,15 @@
         "lower_extreme": null,
         "upper_specification": 0.016,
         "lower_specification": 0.002,
-        "cp_point": 1.08104489790035,
-        "cpk_point": 0.34942275863227057,
+        "cp_point": 1.081,
+        "cpk_point": 0.349,
         "cp_interval": [
-            0.968528969154264, 1.1850469160163335
+            0.969, 1.185
         ],
         "cpk_interval": [
-            0.28682104291055793, 0.39436762851381485
-        ]
+            0.287, 0.394
+        ],
+        "error": null
     },
     "file730": {
         "data": [
@@ -12249,14 +13147,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.05,
         "lower_specification": null,
-        "cp_point": 1.4081368115480266,
-        "cpk_point": 0.9896462764291972,
+        "cp_point": 1.411,
+        "cpk_point": 1.543,
         "cp_interval": [
-            1.1652316587014075, 1.6330840255080823
+            1.168, 1.637
         ],
         "cpk_interval": [
-            0.9866440293353282, 0.9941138523062559
-        ]
+            1.217, 1.884
+        ],
+        "error": null
     },
     "file731": {
         "data": [
@@ -12266,14 +13165,15 @@
         "lower_extreme": null,
         "upper_specification": 34.513,
         "lower_specification": 34.497,
-        "cp_point": 1.0518018708839436,
-        "cpk_point": 1.0256865114713474,
+        "cp_point": 1.052,
+        "cpk_point": 1.026,
         "cp_interval": [
-            0.980910359428778, 1.103361288634465
+            0.981, 1.103
         ],
         "cpk_interval": [
-            0.9404145972361614, 1.071217737845112
-        ]
+            0.94, 1.071
+        ],
+        "error": null
     },
     "file732": {
         "data": [
@@ -12283,14 +13183,15 @@
         "lower_extreme": null,
         "upper_specification": 34.513,
         "lower_specification": 34.497,
-        "cp_point": 1.0274084218326447,
-        "cpk_point": 1.001647957964272,
+        "cp_point": 1.027,
+        "cpk_point": 1.002,
         "cp_interval": [
-            0.9187286274254838, 1.1132925650876178
+            0.919, 1.113
         ],
         "cpk_interval": [
-            0.8822338237012979, 1.0609439171209865
-        ]
+            0.882, 1.061
+        ],
+        "error": null
     },
     "file733": {
         "data": [
@@ -12300,14 +13201,15 @@
         "lower_extreme": null,
         "upper_specification": 34.513,
         "lower_specification": 34.497,
-        "cp_point": 0.9274922652975918,
-        "cpk_point": 0.91680726507969,
+        "cp_point": 0.927,
+        "cpk_point": 0.917,
         "cp_interval": [
-            0.8042348032190156, 1.0198042286524136
+            0.804, 1.02
         ],
         "cpk_interval": [
-            0.7687684787582652, 1.0007603383126895
-        ]
+            0.769, 1.001
+        ],
+        "error": null
     },
     "file734": {
         "data": [
@@ -12317,14 +13219,15 @@
         "lower_extreme": null,
         "upper_specification": 34.513,
         "lower_specification": 34.497,
-        "cp_point": 1.1163268391678065,
-        "cpk_point": 0.8952729505103165,
+        "cp_point": 1.116,
+        "cpk_point": 0.895,
         "cp_interval": [
-            1.0262910453228204, 1.179507941254044
+            1.026, 1.18
         ],
         "cpk_interval": [
-            0.8105785444910255, 0.9778637129647135
-        ]
+            0.811, 0.978
+        ],
+        "error": null
     },
     "file735": {
         "data": [
@@ -12334,14 +13237,15 @@
         "lower_extreme": null,
         "upper_specification": 0.016,
         "lower_specification": 0.002,
-        "cp_point": 1.2808599519931678,
-        "cpk_point": 0.012751769266467584,
+        "cp_point": 1.281,
+        "cpk_point": 0.013,
         "cp_interval": [
-            1.1417952994664171, 1.3573907115590003
+            1.142, 1.357
         ],
         "cpk_interval": [
-            -0.09958531352618312, 0.13737944983623485
-        ]
+            -0.1, 0.137
+        ],
+        "error": null
     },
     "file736": {
         "data": [
@@ -12351,14 +13255,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.05,
         "lower_specification": null,
-        "cp_point": 0.7028521619427454,
-        "cpk_point": 0.6496862093328594,
+        "cp_point": 0.706,
+        "cpk_point": 0.65,
         "cp_interval": [
-            0.5608143360643875, 0.8798777679311137
+            0.563, 0.884
         ],
         "cpk_interval": [
-            0.4986510585070481, 0.8593684979224053
-        ]
+            0.499, 0.859
+        ],
+        "error": null
     },
     "file737": {
         "data": [
@@ -12368,14 +13273,15 @@
         "lower_extreme": null,
         "upper_specification": 42.25,
         "lower_specification": 42.2,
-        "cp_point": 1.6837852396760726,
-        "cpk_point": 1.399876864098637,
+        "cp_point": 1.684,
+        "cpk_point": 1.4,
         "cp_interval": [
-            0.011402355197390657, 2.2861987687649714
+            0.011, 2.286
         ],
         "cpk_interval": [
-            0.008623923620335167, 1.969334254790236
-        ]
+            0.009, 1.969
+        ],
+        "error": null
     },
     "file738": {
         "data": [
@@ -12385,14 +13291,15 @@
         "lower_extreme": null,
         "upper_specification": 42.228,
         "lower_specification": 42.212,
-        "cp_point": 0.7235846999250374,
-        "cpk_point": 0.525930114521539,
+        "cp_point": 0.724,
+        "cpk_point": 0.526,
         "cp_interval": [
-            0.6014129928097046, 0.9548470195558486
+            0.601, 0.955
         ],
         "cpk_interval": [
-            0.3858353833722524, 0.8864725089123258
-        ]
+            0.386, 0.886
+        ],
+        "error": null
     },
     "file739": {
         "data": [
@@ -12402,14 +13309,15 @@
         "lower_extreme": null,
         "upper_specification": 42.228,
         "lower_specification": 42.212,
-        "cp_point": 1.0804752171051784,
-        "cpk_point": 1.0733163480084569,
+        "cp_point": 1.08,
+        "cpk_point": 1.073,
         "cp_interval": [
-            0.9985451686285862, 1.143091164822264
+            0.999, 1.143
         ],
         "cpk_interval": [
-            0.9541678406323215, 1.1213660882228396
-        ]
+            0.954, 1.121
+        ],
+        "error": null
     },
     "file740": {
         "data": [
@@ -12419,14 +13327,15 @@
         "lower_extreme": null,
         "upper_specification": 42.228,
         "lower_specification": 42.212,
-        "cp_point": 0.7268454211259257,
-        "cpk_point": 0.4925983371363641,
+        "cp_point": 0.727,
+        "cpk_point": 0.493,
         "cp_interval": [
-            0.3819217126107972, 1.0282946569258506
+            0.382, 1.028
         ],
         "cpk_interval": [
-            0.18568205073533622, 0.9881194874786386
-        ]
+            0.186, 0.988
+        ],
+        "error": null
     },
     "file741": {
         "data": [
@@ -12436,14 +13345,15 @@
         "lower_extreme": null,
         "upper_specification": 42.228,
         "lower_specification": 42.212,
-        "cp_point": 0.7991525533826878,
-        "cpk_point": 0.40050024378744215,
+        "cp_point": 0.799,
+        "cpk_point": 0.401,
         "cp_interval": [
-            0.6783231763682357, 0.8665744159579477
+            0.678, 0.867
         ],
         "cpk_interval": [
-            0.30169768060395025, 0.46844576287046086
-        ]
+            0.302, 0.468
+        ],
+        "error": null
     },
     "file742": {
         "data": [
@@ -12453,14 +13363,15 @@
         "lower_extreme": null,
         "upper_specification": 0.016,
         "lower_specification": 0.002,
-        "cp_point": 0.4825111199898275,
-        "cpk_point": 0.406225864120093,
+        "cp_point": 0.483,
+        "cpk_point": 0.406,
         "cp_interval": [
-            0.30171612473339027, 0.6195287495749505
+            0.302, 0.62
         ],
         "cpk_interval": [
-            0.29005248844203063, 0.4423440604051958
-        ]
+            0.29, 0.442
+        ],
+        "error": null
     },
     "file743": {
         "data": [
@@ -12470,14 +13381,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.05,
         "lower_specification": null,
-        "cp_point": 1.4022755794144928,
-        "cpk_point": 0.9871056093740811,
+        "cp_point": 1.407,
+        "cpk_point": 1.553,
         "cp_interval": [
-            1.247926113832992, 1.5727701478578702
+            1.252, 1.578
         ],
         "cpk_interval": [
-            0.983057490508071, 0.9940158355808459
-        ]
+            1.327, 1.829
+        ],
+        "error": null
     },
     "file744": {
         "data": [
@@ -12487,14 +13399,15 @@
         "lower_extreme": null,
         "upper_specification": 42.25,
         "lower_specification": 42.2,
-        "cp_point": 1.1349164846536794,
-        "cpk_point": 0.9743268883089486,
+        "cp_point": 1.135,
+        "cpk_point": 0.974,
         "cp_interval": [
-            0.5067635529482449, 1.4352858936967596
+            0.507, 1.435
         ],
         "cpk_interval": [
-            0.2781354617550514, 1.304703983971794
-        ]
+            0.278, 1.305
+        ],
+        "error": null
     },
     "file745": {
         "data": [
@@ -12504,14 +13417,15 @@
         "lower_extreme": null,
         "upper_specification": 42.25,
         "lower_specification": 42.2,
-        "cp_point": 0.7694250100317118,
-        "cpk_point": 0.6729749672746999,
+        "cp_point": 0.769,
+        "cpk_point": 0.673,
         "cp_interval": [
-            0.24280938953907383, 1.1883369672649582
+            0.243, 1.188
         ],
         "cpk_interval": [
-            0.1489445001252377, 1.125091616842932
-        ]
+            0.149, 1.125
+        ],
+        "error": null
     },
     "file746": {
         "data": [
@@ -12521,14 +13435,15 @@
         "lower_extreme": null,
         "upper_specification": 42.25,
         "lower_specification": 42.2,
-        "cp_point": 0.9921677025073894,
-        "cpk_point": 0.8077748202615277,
+        "cp_point": 0.992,
+        "cpk_point": 0.808,
         "cp_interval": [
-            0.4088391178254248, 1.4484610554895039
+            0.409, 1.448
         ],
         "cpk_interval": [
-            0.24149600581545694, 1.27976337262766
-        ]
+            0.241, 1.28
+        ],
+        "error": null
     },
     "file747": {
         "data": [
@@ -12538,14 +13453,15 @@
         "lower_extreme": null,
         "upper_specification": 34.513,
         "lower_specification": 34.497,
-        "cp_point": 1.075019703893392,
-        "cpk_point": 1.0635210540777014,
+        "cp_point": 1.075,
+        "cpk_point": 1.064,
         "cp_interval": [
-            0.9104682634735473, 1.202592377277533
+            0.91, 1.203
         ],
         "cpk_interval": [
-            0.8623624505810634, 1.1528549219186146
-        ]
+            0.862, 1.153
+        ],
+        "error": null
     },
     "file748": {
         "data": [
@@ -12555,14 +13471,15 @@
         "lower_extreme": null,
         "upper_specification": 34.513,
         "lower_specification": 34.497,
-        "cp_point": 1.045108112334415,
-        "cpk_point": 1.0342113231564456,
+        "cp_point": 1.045,
+        "cpk_point": 1.034,
         "cp_interval": [
-            0.8918435952969987, 1.172087015887254
+            0.892, 1.172
         ],
         "cpk_interval": [
-            0.8420391229893691, 1.0943296896698325
-        ]
+            0.842, 1.094
+        ],
+        "error": null
     },
     "file749": {
         "data": [
@@ -12572,14 +13489,15 @@
         "lower_extreme": null,
         "upper_specification": 34.513,
         "lower_specification": 34.497,
-        "cp_point": 0.8067900580156131,
-        "cpk_point": 0.7978036839948193,
+        "cp_point": 0.807,
+        "cpk_point": 0.798,
         "cp_interval": [
-            0.6958124869576146, 0.9198684386183132
+            0.696, 0.92
         ],
         "cpk_interval": [
-            0.6678197006465244, 0.9078316383308207
-        ]
+            0.668, 0.908
+        ],
+        "error": null
     },
     "file750": {
         "data": [
@@ -12589,14 +13507,15 @@
         "lower_extreme": null,
         "upper_specification": 34.513,
         "lower_specification": 34.497,
-        "cp_point": 0.9660873583872466,
-        "cpk_point": 0.762700471698598,
+        "cp_point": 0.966,
+        "cpk_point": 0.763,
         "cp_interval": [
-            0.7725450062559737, 1.1469974420844022
+            0.773, 1.147
         ],
         "cpk_interval": [
-            0.6363927440254686, 0.8906224001434068
-        ]
+            0.636, 0.891
+        ],
+        "error": null
     },
     "file751": {
         "data": [
@@ -12606,14 +13525,15 @@
         "lower_extreme": null,
         "upper_specification": 0.016,
         "lower_specification": 0.002,
-        "cp_point": 0.9117259252384704,
-        "cpk_point": -0.15482667897705035,
+        "cp_point": 0.912,
+        "cpk_point": -0.155,
         "cp_interval": [
-            0.736350883635331, 1.0571951002482196
+            0.736, 1.057
         ],
         "cpk_interval": [
-            -0.23784004243089094, -0.07982900686720454
-        ]
+            -0.238, -0.08
+        ],
+        "error": null
     },
     "file752": {
         "data": [
@@ -12623,14 +13543,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.05,
         "lower_specification": null,
-        "cp_point": 0.47653458156445033,
-        "cpk_point": 0.4140954481009513,
+        "cp_point": 0.478,
+        "cpk_point": 0.414,
         "cp_interval": [
-            0.37345522019782734, 0.6090709548684893
+            0.374, 0.61
         ],
         "cpk_interval": [
-            0.31525955116560755, 0.5562852069915663
-        ]
+            0.315, 0.556
+        ],
+        "error": null
     },
     "file753": {
         "data": [
@@ -12639,7 +13560,16 @@
         "upper_extreme": null,
         "lower_extreme": null,
         "upper_specification": 34.521,
-        "lower_specification": 34.472
+        "lower_specification": 34.472,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More unique values are required to calculate capability indexes."
     },
     "file754": {
         "data": [
@@ -12648,7 +13578,16 @@
         "upper_extreme": null,
         "lower_extreme": null,
         "upper_specification": 34.521,
-        "lower_specification": 34.472
+        "lower_specification": 34.472,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More unique values are required to calculate capability indexes."
     },
     "file755": {
         "data": [
@@ -12657,7 +13596,16 @@
         "upper_extreme": null,
         "lower_extreme": null,
         "upper_specification": 34.521,
-        "lower_specification": 34.472
+        "lower_specification": 34.472,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More unique values are required to calculate capability indexes."
     },
     "file756": {
         "data": [
@@ -12667,14 +13615,15 @@
         "lower_extreme": null,
         "upper_specification": 71.451,
         "lower_specification": 71.379,
-        "cp_point": 1.2443243274677291,
-        "cpk_point": 1.2132139582010313,
+        "cp_point": 1.244,
+        "cpk_point": 1.213,
         "cp_interval": [
-            1.1050439150418248, 1.3282131322274455
+            1.105, 1.328
         ],
         "cpk_interval": [
-            1.0309654127632566, 1.3186091807096054
-        ]
+            1.031, 1.319
+        ],
+        "error": null
     },
     "file757": {
         "data": [
@@ -12684,14 +13633,15 @@
         "lower_extreme": null,
         "upper_specification": 67.74,
         "lower_specification": 67.68,
-        "cp_point": 0.5121107790931951,
-        "cpk_point": 0.2922110435589734,
+        "cp_point": 0.512,
+        "cpk_point": 0.292,
         "cp_interval": [
-            0.21834304938975285, 0.950643875335514
+            0.218, 0.951
         ],
         "cpk_interval": [
-            0.11149172381901677, 0.902990713954129
-        ]
+            0.111, 0.903
+        ],
+        "error": null
     },
     "file758": {
         "data": [
@@ -12701,14 +13651,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.035,
         "lower_specification": null,
-        "cp_point": 0.9111472726102631,
-        "cpk_point": 0.8826789599058782,
+        "cp_point": 0.928,
+        "cpk_point": 0.883,
         "cp_interval": [
-            0.8340695291149032, 0.974920556884738
+            0.849, 0.992
         ],
         "cpk_interval": [
-            0.7721705731410966, 0.9647317244067133
-        ]
+            0.772, 0.98
+        ],
+        "error": null
     },
     "file759": {
         "data": [
@@ -12718,14 +13669,15 @@
         "lower_extreme": null,
         "upper_specification": 65.202,
         "lower_specification": 65.142,
-        "cp_point": 1.040116701629948,
-        "cpk_point": 0.9773612754377105,
+        "cp_point": 1.04,
+        "cpk_point": 0.977,
         "cp_interval": [
-            0.9453785744839092, 1.1216777459582754
+            0.945, 1.122
         ],
         "cpk_interval": [
-            0.8527676235556971, 1.0797348065101815
-        ]
+            0.853, 1.08
+        ],
+        "error": null
     },
     "file760": {
         "data": [
@@ -12735,14 +13687,15 @@
         "lower_extreme": null,
         "upper_specification": 74.635,
         "lower_specification": 74.563,
-        "cp_point": 0.9839026275574326,
-        "cpk_point": 0.9255106540103137,
+        "cp_point": 0.984,
+        "cpk_point": 0.926,
         "cp_interval": [
-            0.8201668178862848, 1.0841709678955016
+            0.82, 1.084
         ],
         "cpk_interval": [
-            0.7040960704067739, 1.0436562419611042
-        ]
+            0.704, 1.044
+        ],
+        "error": null
     },
     "file761": {
         "data": [
@@ -12752,14 +13705,15 @@
         "lower_extreme": null,
         "upper_specification": 71.451,
         "lower_specification": 71.379,
-        "cp_point": 1.1724819816144183,
-        "cpk_point": 1.0831123958896953,
+        "cp_point": 1.172,
+        "cpk_point": 1.083,
         "cp_interval": [
-            0.9678886994239927, 1.3207803045976536
+            0.968, 1.321
         ],
         "cpk_interval": [
-            0.8477075462472871, 1.2744919170758982
-        ]
+            0.848, 1.274
+        ],
+        "error": null
     },
     "file762": {
         "data": [
@@ -12769,14 +13723,15 @@
         "lower_extreme": null,
         "upper_specification": 67.74,
         "lower_specification": 67.68,
-        "cp_point": 1.2585161515137335,
-        "cpk_point": 1.2359935915528772,
+        "cp_point": 1.259,
+        "cpk_point": 1.236,
         "cp_interval": [
-            1.1000082230374728, 1.342311038673657
+            1.1, 1.342
         ],
         "cpk_interval": [
-            1.0258868779388257, 1.3300272189703328
-        ]
+            1.026, 1.33
+        ],
+        "error": null
     },
     "file763": {
         "data": [
@@ -12786,14 +13741,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.035,
         "lower_specification": null,
-        "cp_point": 0.8187123364574493,
-        "cpk_point": 0.7390879221344927,
+        "cp_point": 0.824,
+        "cpk_point": 0.739,
         "cp_interval": [
-            0.6954611104157299, 0.9046809698346007
+            0.7, 0.91
         ],
         "cpk_interval": [
-            0.5838797333310405, 0.8600364685185145
-        ]
+            0.584, 0.86
+        ],
+        "error": null
     },
     "file764": {
         "data": [
@@ -12803,14 +13759,15 @@
         "lower_extreme": null,
         "upper_specification": 65.202,
         "lower_specification": 65.142,
-        "cp_point": 1.146915459669789,
-        "cpk_point": 1.091235434048855,
+        "cp_point": 1.147,
+        "cpk_point": 1.091,
         "cp_interval": [
-            0.9560787370028219, 1.2237734326524423
+            0.956, 1.224
         ],
         "cpk_interval": [
-            0.8837387570370564, 1.1868750583648047
-        ]
+            0.884, 1.187
+        ],
+        "error": null
     },
     "file765": {
         "data": [
@@ -12820,14 +13777,15 @@
         "lower_extreme": null,
         "upper_specification": 74.635,
         "lower_specification": 74.563,
-        "cp_point": 1.1515884775776652,
-        "cpk_point": 1.0298368781657594,
+        "cp_point": 1.152,
+        "cpk_point": 1.03,
         "cp_interval": [
-            1.0075388030458414, 1.2697601424747138
+            1.008, 1.27
         ],
         "cpk_interval": [
-            0.8702044785634695, 1.156944332220587
-        ]
+            0.87, 1.157
+        ],
+        "error": null
     },
     "file766": {
         "data": [
@@ -12837,14 +13795,15 @@
         "lower_extreme": null,
         "upper_specification": 76.95,
         "lower_specification": 76.75,
-        "cp_point": 1.336391006060572,
-        "cpk_point": 1.2530019522400968,
+        "cp_point": 1.336,
+        "cpk_point": 1.253,
         "cp_interval": [
-            0.9579626512961941, 1.6741254041887985
+            0.958, 1.674
         ],
         "cpk_interval": [
-            0.9190754520638025, 1.4996460009925778
-        ]
+            0.919, 1.5
+        ],
+        "error": null
     },
     "file767": {
         "data": [
@@ -12854,14 +13813,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.5278556898017941,
-        "cpk_point": 0.4890322797270947,
+        "cp_point": 0.546,
+        "cpk_point": 0.489,
         "cp_interval": [
-            0.03317789850040625, 1.5917373712692158
+            0.034, 1.647
         ],
         "cpk_interval": [
-            0.027116556093792463, 0.9711368354431238
-        ]
+            0.027, 1.885
+        ],
+        "error": null
     },
     "file768": {
         "data": [
@@ -12871,14 +13831,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 2.030617279504251,
-        "cpk_point": 0.904482012091377,
+        "cp_point": 2.137,
+        "cpk_point": 2.663,
         "cp_interval": [
-            1.524642709270314, 2.493439883833687
+            1.605, 2.625
         ],
         "cpk_interval": [
-            0.7811725693873955, 1.0069722675039037
-        ]
+            1.839, 3.432
+        ],
+        "error": null
     },
     "file769": {
         "data": [
@@ -12888,14 +13849,15 @@
         "lower_extreme": null,
         "upper_specification": 74.222,
         "lower_specification": 74.163,
-        "cp_point": 1.0953648542901342,
-        "cpk_point": 0.9835974438629617,
+        "cp_point": 1.095,
+        "cpk_point": 0.984,
         "cp_interval": [
-            0.6487107320260831, 1.571847791833113
+            0.649, 1.572
         ],
         "cpk_interval": [
-            0.4883637611259486, 1.4687352295956968
-        ]
+            0.488, 1.469
+        ],
+        "error": null
     },
     "file770": {
         "data": [
@@ -12905,14 +13867,15 @@
         "lower_extreme": null,
         "upper_specification": 74.222,
         "lower_specification": 74.163,
-        "cp_point": 0.9486470130604171,
-        "cpk_point": 0.8359689632917539,
+        "cp_point": 0.949,
+        "cpk_point": 0.836,
         "cp_interval": [
-            0.5051686880482281, 1.4763140154413468
+            0.505, 1.476
         ],
         "cpk_interval": [
-            0.4018803227408265, 1.325884218732984
-        ]
+            0.402, 1.326
+        ],
+        "error": null
     },
     "file771": {
         "data": [
@@ -12922,14 +13885,15 @@
         "lower_extreme": null,
         "upper_specification": 74.222,
         "lower_specification": 74.163,
-        "cp_point": 1.1823230055413687,
-        "cpk_point": 1.0454111697417203,
+        "cp_point": 1.182,
+        "cpk_point": 1.045,
         "cp_interval": [
-            0.7211017941758338, 1.6821624677417562
+            0.721, 1.682
         ],
         "cpk_interval": [
-            0.53550993703742, 1.5561739457790345
-        ]
+            0.536, 1.556
+        ],
+        "error": null
     },
     "file772": {
         "data": [
@@ -12939,14 +13903,15 @@
         "lower_extreme": null,
         "upper_specification": -6.0,
         "lower_specification": -24.0,
-        "cp_point": 1.1352580833669796,
-        "cpk_point": 0.8040791979607715,
+        "cp_point": 1.135,
+        "cpk_point": 0.804,
         "cp_interval": [
-            0.4761922406216911, 1.487363941083911
+            0.476, 1.487
         ],
         "cpk_interval": [
-            0.30533652012705004, 1.1773615926266232
-        ]
+            0.305, 1.177
+        ],
+        "error": null
     },
     "file773": {
         "data": [
@@ -12956,14 +13921,15 @@
         "lower_extreme": null,
         "upper_specification": -6.0,
         "lower_specification": -24.0,
-        "cp_point": 1.1150818099342872,
-        "cpk_point": 0.41729068678008346,
+        "cp_point": 1.115,
+        "cpk_point": 0.417,
         "cp_interval": [
-            0.6801956225599811, 1.4594539838389684
+            0.68, 1.459
         ],
         "cpk_interval": [
-            0.22397310956270225, 0.5978752924251598
-        ]
+            0.224, 0.598
+        ],
+        "error": null
     },
     "file774": {
         "data": [
@@ -12973,14 +13939,15 @@
         "lower_extreme": null,
         "upper_specification": -6.0,
         "lower_specification": -24.0,
-        "cp_point": 1.181172876162118,
-        "cpk_point": 0.8627062049435493,
+        "cp_point": 1.181,
+        "cpk_point": 0.863,
         "cp_interval": [
-            0.7815145330109625, 1.513997504291113
+            0.782, 1.514
         ],
         "cpk_interval": [
-            0.4951754513988956, 1.1259420037911916
-        ]
+            0.495, 1.126
+        ],
+        "error": null
     },
     "file775": {
         "data": [
@@ -12990,14 +13957,15 @@
         "lower_extreme": null,
         "upper_specification": -6.0,
         "lower_specification": -24.0,
-        "cp_point": 0.937035282342834,
-        "cpk_point": 0.2648748529682369,
+        "cp_point": 0.937,
+        "cpk_point": 0.265,
         "cp_interval": [
-            0.6154240621261621, 1.2225026936906123
+            0.615, 1.223
         ],
         "cpk_interval": [
-            0.10902959328218563, 0.4266267287649637
-        ]
+            0.109, 0.427
+        ],
+        "error": null
     },
     "file776": {
         "data": [
@@ -13007,14 +13975,15 @@
         "lower_extreme": null,
         "upper_specification": 26.0,
         "lower_specification": 14.0,
-        "cp_point": 2.101454622933244,
-        "cpk_point": 1.3617243401385415,
+        "cp_point": 2.101,
+        "cpk_point": 1.362,
         "cp_interval": [
-            1.4893175746087117, 2.6418506545247764
+            1.489, 2.642
         ],
         "cpk_interval": [
-            1.0355696935571717, 1.6422271205596546
-        ]
+            1.036, 1.642
+        ],
+        "error": null
     },
     "file777": {
         "data": [
@@ -13024,14 +13993,15 @@
         "lower_extreme": null,
         "upper_specification": 26.0,
         "lower_specification": 14.0,
-        "cp_point": 2.058166474565712,
-        "cpk_point": 1.1110195575670847,
+        "cp_point": 2.058,
+        "cpk_point": 1.111,
         "cp_interval": [
-            1.4966897809887494, 2.5382595788746563
+            1.497, 2.538
         ],
         "cpk_interval": [
-            0.7707910425380277, 1.3824432982693986
-        ]
+            0.771, 1.382
+        ],
+        "error": null
     },
     "file778": {
         "data": [
@@ -13041,14 +14011,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.5322000660030972,
-        "cpk_point": 1.121046342137634,
+        "cp_point": 1.532,
+        "cpk_point": 1.121,
         "cp_interval": [
-            1.1226626507320252, 1.7538773555754883
+            1.123, 1.754
         ],
         "cpk_interval": [
-            0.8548267341596755, 1.3806145767752
-        ]
+            0.855, 1.381
+        ],
+        "error": null
     },
     "file779": {
         "data": [
@@ -13058,14 +14029,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.339178114327541,
-        "cpk_point": 1.0787218563540506,
+        "cp_point": 1.339,
+        "cpk_point": 1.079,
         "cp_interval": [
-            0.9727012566713389, 1.6656851647208673
+            0.973, 1.666
         ],
         "cpk_interval": [
-            0.7483035945339315, 1.4311926029612465
-        ]
+            0.748, 1.431
+        ],
+        "error": null
     },
     "file780": {
         "data": [
@@ -13075,14 +14047,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": 2.0,
-        "cp_point": 0.7742558386662394,
-        "cpk_point": 0.5742691057134742,
+        "cp_point": 0.774,
+        "cpk_point": 0.574,
         "cp_interval": [
-            0.5772557965820264, 0.9555573322081019
+            0.577, 0.956
         ],
         "cpk_interval": [
-            0.41656938567265067, 0.7669285508742006
-        ]
+            0.417, 0.767
+        ],
+        "error": null
     },
     "file781": {
         "data": [
@@ -13092,14 +14065,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": 2.0,
-        "cp_point": 0.7973398609797785,
-        "cpk_point": 0.2090052491715852,
+        "cp_point": 0.797,
+        "cpk_point": 0.209,
         "cp_interval": [
-            0.5849352813785087, 0.9842690029712573
+            0.585, 0.984
         ],
         "cpk_interval": [
-            0.09600651728782597, 0.36080832004626995
-        ]
+            0.096, 0.361
+        ],
+        "error": null
     },
     "file782": {
         "data": [
@@ -13109,14 +14083,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": -6.0,
-        "cp_point": 2.2823355017725597,
-        "cpk_point": 2.281205962482686,
+        "cp_point": 2.282,
+        "cpk_point": 2.281,
         "cp_interval": [
-            1.6369118420891988, 2.857207444126471
+            1.637, 2.857
         ],
         "cpk_interval": [
-            1.555160172223575, 2.733242230957839
-        ]
+            1.555, 2.733
+        ],
+        "error": null
     },
     "file783": {
         "data": [
@@ -13126,14 +14101,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": -6.0,
-        "cp_point": 2.792792669895545,
-        "cpk_point": 2.7204872081106086,
+        "cp_point": 2.793,
+        "cpk_point": 2.72,
         "cp_interval": [
-            2.0279454791237628, 3.4921611422390444
+            2.028, 3.492
         ],
         "cpk_interval": [
-            1.888171163136356, 3.39415034367506
-        ]
+            1.888, 3.394
+        ],
+        "error": null
     },
     "file784": {
         "data": [
@@ -13143,14 +14119,15 @@
         "lower_extreme": null,
         "upper_specification": -6.0,
         "lower_specification": -24.0,
-        "cp_point": 1.3580431882828257,
-        "cpk_point": 1.2697047339003884,
+        "cp_point": 1.358,
+        "cpk_point": 1.27,
         "cp_interval": [
-            0.9120830235933667, 1.7425467982865168
+            0.912, 1.743
         ],
         "cpk_interval": [
-            0.8007826803845273, 1.6530760200113237
-        ]
+            0.801, 1.653
+        ],
+        "error": null
     },
     "file785": {
         "data": [
@@ -13160,14 +14137,15 @@
         "lower_extreme": null,
         "upper_specification": -6.0,
         "lower_specification": -24.0,
-        "cp_point": 1.6491289100253554,
-        "cpk_point": 1.6284456295700642,
+        "cp_point": 1.649,
+        "cpk_point": 1.628,
         "cp_interval": [
-            1.290468089548159, 1.9302843085261365
+            1.29, 1.93
         ],
         "cpk_interval": [
-            1.0801334430944198, 1.8156157889366076
-        ]
+            1.08, 1.816
+        ],
+        "error": null
     },
     "file786": {
         "data": [
@@ -13177,14 +14155,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.2241701629203922,
-        "cpk_point": 0.15596001087120495,
+        "cp_point": 0.462,
+        "cpk_point": 0.156,
         "cp_interval": [
-            0.0841833583654212, 0.39504117838378533
+            0.173, 0.814
         ],
         "cpk_interval": [
-            0.05178535457713736, 0.32426594303933887
-        ]
+            0.052, 0.324
+        ],
+        "error": null
     },
     "file787": {
         "data": [
@@ -13194,14 +14173,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 3.4743293916396167,
-        "cpk_point": 0.8634669482875016,
+        "cp_point": 3.633,
+        "cpk_point": 4.951,
         "cp_interval": [
-            2.617926796890378, 4.249063882041255
+            2.738, 4.443
         ],
         "cpk_interval": [
-            0.7209675385694494, 0.9737615032391346
-        ]
+            3.468, 6.266
+        ],
+        "error": null
     },
     "file788": {
         "data": [
@@ -13211,14 +14191,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.5842408245756989,
-        "cpk_point": 0.48001373114693513,
+        "cp_point": 0.809,
+        "cpk_point": 0.48,
         "cp_interval": [
-            0.38202156133093623, 0.8228817499767329
+            0.529, 1.139
         ],
         "cpk_interval": [
-            0.24869167988415392, 0.74666217617827
-        ]
+            0.249, 0.794
+        ],
+        "error": null
     },
     "file789": {
         "data": [
@@ -13228,14 +14209,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 4.639961001246944,
-        "cpk_point": 0.943637878926587,
+        "cp_point": 4.868,
+        "cpk_point": 7.0,
         "cp_interval": [
-            3.4968719278302345, 5.647687896121432
+            3.669, 5.925
         ],
         "cpk_interval": [
-            0.7689309562195235, 1.0777955870906217
-        ]
+            4.991, 8.819
+        ],
+        "error": null
     },
     "file790": {
         "data": [
@@ -13245,14 +14227,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 3.8059185936874877,
-        "cpk_point": 0.8433133869820243,
+        "cp_point": 4.135,
+        "cpk_point": 6.931,
         "cp_interval": [
-            2.973002408095354, 4.359419798252889
+            3.23, 4.736
         ],
         "cpk_interval": [
-            0.601071565117876, 0.9719422860698644
-        ]
+            5.078, 8.729
+        ],
+        "error": null
     },
     "file791": {
         "data": [
@@ -13262,14 +14245,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.14853358463724,
-        "cpk_point": 0.7365514898212642,
+        "cp_point": 1.298,
+        "cpk_point": 1.378,
         "cp_interval": [
-            0.8652723765222804, 1.4088872375579915
+            0.978, 1.593
         ],
         "cpk_interval": [
-            0.6086614958307532, 0.8319467394364153
-        ]
+            0.949, 1.811
+        ],
+        "error": null
     },
     "file792": {
         "data": [
@@ -13279,14 +14263,15 @@
         "lower_extreme": null,
         "upper_specification": 62.85,
         "lower_specification": 62.6,
-        "cp_point": 2.5195265686980006,
-        "cpk_point": 2.488407196738055,
+        "cp_point": 2.52,
+        "cpk_point": 2.488,
         "cp_interval": [
-            1.8669090623356919, 2.86832052902565
+            1.867, 2.868
         ],
         "cpk_interval": [
-            1.6073760368690937, 2.836724257999485
-        ]
+            1.607, 2.837
+        ],
+        "error": null
     },
     "file793": {
         "data": [
@@ -13296,14 +14281,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.0484855917219473,
-        "cpk_point": 0.7386213309004976,
+        "cp_point": 1.589,
+        "cpk_point": 1.408,
         "cp_interval": [
-            0.7992873874675818, 1.2801063134882105
+            1.211, 1.94
         ],
         "cpk_interval": [
-            0.5454894119076817, 0.8984569863083057
-        ]
+            1.054, 1.735
+        ],
+        "error": null
     },
     "file794": {
         "data": [
@@ -13313,14 +14299,15 @@
         "lower_extreme": null,
         "upper_specification": 30.015,
         "lower_specification": 30.002,
-        "cp_point": 1.236416674626892,
-        "cpk_point": 1.1920065074209063,
+        "cp_point": 1.236,
+        "cpk_point": 1.192,
         "cp_interval": [
-            1.126554745218468, 1.3322633907807726
+            1.127, 1.332
         ],
         "cpk_interval": [
-            1.0745507697877468, 1.287531834717012
-        ]
+            1.075, 1.288
+        ],
+        "error": null
     },
     "file795": {
         "data": [
@@ -13330,14 +14317,15 @@
         "lower_extreme": null,
         "upper_specification": 29.9,
         "lower_specification": 29.8,
-        "cp_point": 5.842269305455895,
-        "cpk_point": 4.713650217531865,
+        "cp_point": 5.842,
+        "cpk_point": 4.714,
         "cp_interval": [
-            5.260311831798013, 6.306551898515276
+            5.26, 6.307
         ],
         "cpk_interval": [
-            4.0841575529635925, 5.182960917760135
-        ]
+            4.084, 5.183
+        ],
+        "error": null
     },
     "file796": {
         "data": [
@@ -13347,14 +14335,15 @@
         "lower_extreme": null,
         "upper_specification": 35.0,
         "lower_specification": 34.989,
-        "cp_point": 1.1176668568221104,
-        "cpk_point": 1.1153361485458133,
+        "cp_point": 1.118,
+        "cpk_point": 1.115,
         "cp_interval": [
-            0.99755549203422, 1.2236575200260635
+            0.998, 1.224
         ],
         "cpk_interval": [
-            0.9778404248085809, 1.1879872700577254
-        ]
+            0.978, 1.188
+        ],
+        "error": null
     },
     "file797": {
         "data": [
@@ -13364,14 +14353,15 @@
         "lower_extreme": null,
         "upper_specification": 35.0,
         "lower_specification": 34.989,
-        "cp_point": 1.060503594433971,
-        "cpk_point": 0.9975410893528408,
+        "cp_point": 1.061,
+        "cpk_point": 0.998,
         "cp_interval": [
-            0.9733708605573165, 1.1611268743860652
+            0.973, 1.161
         ],
         "cpk_interval": [
-            0.8760158913963441, 1.1064917416249747
-        ]
+            0.876, 1.106
+        ],
+        "error": null
     },
     "file798": {
         "data": [
@@ -13381,14 +14371,15 @@
         "lower_extreme": null,
         "upper_specification": 24.0,
         "lower_specification": 23.991,
-        "cp_point": 1.2619903106652866,
-        "cpk_point": 1.249288168041451,
+        "cp_point": 1.262,
+        "cpk_point": 1.249,
         "cp_interval": [
-            1.140254109746382, 1.3930173041261953
+            1.14, 1.393
         ],
         "cpk_interval": [
-            1.117354891518398, 1.3343725819632228
-        ]
+            1.117, 1.334
+        ],
+        "error": null
     },
     "file799": {
         "data": [
@@ -13398,14 +14389,15 @@
         "lower_extreme": null,
         "upper_specification": 24.0,
         "lower_specification": 23.991,
-        "cp_point": 1.0908165913305266,
-        "cpk_point": 1.0681637893269516,
+        "cp_point": 1.091,
+        "cpk_point": 1.068,
         "cp_interval": [
-            1.0003727409167011, 1.1730623457295273
+            1.0, 1.173
         ],
         "cpk_interval": [
-            0.9818059232981884, 1.151611808240669
-        ]
+            0.982, 1.152
+        ],
+        "error": null
     },
     "file800": {
         "data": [
@@ -13415,14 +14407,15 @@
         "lower_extreme": null,
         "upper_specification": 15.0,
         "lower_specification": 14.992,
-        "cp_point": 0.9009766805791628,
-        "cpk_point": 0.8674779954516313,
+        "cp_point": 0.901,
+        "cpk_point": 0.867,
         "cp_interval": [
-            0.7799923320551061, 0.9908528628086334
+            0.78, 0.991
         ],
         "cpk_interval": [
-            0.7150751386174116, 0.9841444069832899
-        ]
+            0.715, 0.984
+        ],
+        "error": null
     },
     "file801": {
         "data": [
@@ -13432,14 +14425,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 1.6391630494059175,
-        "cpk_point": 0.835469538272798,
+        "cp_point": 1.684,
+        "cpk_point": 1.771,
         "cp_interval": [
-            0.08451689702741637, 3.5506284754494457
+            0.087, 3.647
         ],
         "cpk_interval": [
-            0.07889640314902399, 0.8884350788666728
-        ]
+            0.079, 4.958
+        ],
+        "error": null
     },
     "file802": {
         "data": [
@@ -13449,14 +14443,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.03,
         "lower_specification": null,
-        "cp_point": 0.2084524863498031,
-        "cpk_point": 0.20006653976474517,
+        "cp_point": 0.216,
+        "cpk_point": 0.2,
         "cp_interval": [
-            2.5875793656286497e-06, 2.5660197708042483
+            0.0, 2.655
         ],
         "cpk_interval": [
-            2.4535324214477692e-06, 0.9215274007735044
-        ]
+            0.0, 2.864
+        ],
+        "error": null
     },
     "file803": {
         "data": [
@@ -13466,14 +14461,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.03,
         "lower_specification": null,
-        "cp_point": 2.3686637697850528,
-        "cpk_point": 0.942802803960877,
+        "cp_point": 2.414,
+        "cpk_point": 2.602,
         "cp_interval": [
-            1.8652206271583458, 2.7573260830461166
+            1.901, 2.81
         ],
         "cpk_interval": [
-            0.889046380575453, 0.9877833517609086
-        ]
+            1.995, 3.101
+        ],
+        "error": null
     },
     "file804": {
         "data": [
@@ -13483,14 +14479,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 0.8738079321911028,
-        "cpk_point": 0.8664978675696835,
+        "cp_point": 0.898,
+        "cpk_point": 0.874,
         "cp_interval": [
-            0.5550307760591308, 1.1502303252062025
+            0.57, 1.181
         ],
         "cpk_interval": [
-            0.5426942035159189, 0.9037261582744638
-        ]
+            0.543, 1.174
+        ],
+        "error": null
     },
     "file805": {
         "data": [
@@ -13500,14 +14497,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.02,
         "lower_specification": null,
-        "cp_point": 0.9320254358999144,
-        "cpk_point": 0.9164541324936066,
+        "cp_point": 0.964,
+        "cpk_point": 0.916,
         "cp_interval": [
-            0.8782633249447921, 0.9740966707974889
+            0.908, 1.007
         ],
         "cpk_interval": [
-            0.8287327298399254, 0.9638243316819975
-        ]
+            0.829, 0.986
+        ],
+        "error": null
     },
     "file806": {
         "data": [
@@ -13517,14 +14515,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.03,
         "lower_specification": null,
-        "cp_point": 2.1129218652559585,
-        "cpk_point": 0.849025972703462,
+        "cp_point": 2.15,
+        "cpk_point": 2.242,
         "cp_interval": [
-            1.4888119005317186, 2.5045279541885317
+            1.515, 2.548
         ],
         "cpk_interval": [
-            0.8041243793643009, 0.8914543654640305
-        ]
+            1.535, 2.706
+        ],
+        "error": null
     },
     "file807": {
         "data": [
@@ -13534,14 +14533,15 @@
         "lower_extreme": null,
         "upper_specification": 44.025,
         "lower_specification": 44.009,
-        "cp_point": 0.07496725426711319,
-        "cpk_point": 0.03959368494229052,
+        "cp_point": 0.075,
+        "cpk_point": 0.04,
         "cp_interval": [
-            0.0006720376724419389, 0.8257044383539973
+            0.001, 0.826
         ],
         "cpk_interval": [
-            0.0003416992330963618, 0.6663353209171881
-        ]
+            0.0, 0.666
+        ],
+        "error": null
     },
     "file808": {
         "data": [
@@ -13551,14 +14551,15 @@
         "lower_extreme": null,
         "upper_specification": 44.025,
         "lower_specification": 44.009,
-        "cp_point": 0.06032697640590686,
-        "cpk_point": 0.027162794268237065,
+        "cp_point": 0.06,
+        "cpk_point": 0.027,
         "cp_interval": [
-            0.00023320921523678004, 1.1785509502533276
+            0.0, 1.179
         ],
         "cpk_interval": [
-            0.00010013453164960042, 0.958581854109411
-        ]
+            0.0, 0.959
+        ],
+        "error": null
     },
     "file809": {
         "data": [
@@ -13568,14 +14569,15 @@
         "lower_extreme": null,
         "upper_specification": 28.02,
         "lower_specification": 28.009,
-        "cp_point": 0.04579773766470877,
-        "cpk_point": 0.018988332505038806,
+        "cp_point": 0.046,
+        "cpk_point": 0.019,
         "cp_interval": [
-            7.504127832669973e-06, 1.0330282097891026
+            0.0, 1.033
         ],
         "cpk_interval": [
-            3.1135133778549998e-06, 0.9023970135338186
-        ]
+            0.0, 0.902
+        ],
+        "error": null
     },
     "file810": {
         "data": [
@@ -13585,14 +14587,15 @@
         "lower_extreme": null,
         "upper_specification": 28.02,
         "lower_specification": 28.009,
-        "cp_point": 0.04278180126944601,
-        "cpk_point": 0.016042233237527813,
+        "cp_point": 0.043,
+        "cpk_point": 0.016,
         "cp_interval": [
-            0.005834952776104681, 0.858154022936267
+            0.006, 0.858
         ],
         "cpk_interval": [
-            0.001974562553433594, 0.6329472372474112
-        ]
+            0.002, 0.633
+        ],
+        "error": null
     },
     "file811": {
         "data": [
@@ -13602,14 +14605,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.005,
         "lower_specification": null,
-        "cp_point": 0.05898425818133867,
-        "cpk_point": 0.04760386906984134,
+        "cp_point": 0.059,
+        "cpk_point": 0.048,
         "cp_interval": [
-            0.01771080649079398, 0.9908810985670015
+            0.018, 0.995
         ],
         "cpk_interval": [
-            0.01417064153496386, 0.9865071363310782
-        ]
+            0.014, 0.991
+        ],
+        "error": null
     },
     "file812": {
         "data": [
@@ -13619,14 +14623,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.005,
         "lower_specification": null,
-        "cp_point": 0.03103170668859376,
-        "cpk_point": 0.023938944646551465,
+        "cp_point": 0.031,
+        "cpk_point": 0.024,
         "cp_interval": [
-            0.007992635834218617, 0.891238857259819
+            0.008, 0.895
         ],
         "cpk_interval": [
-            0.0061211619095581146, 0.8648660150217008
-        ]
+            0.006, 0.865
+        ],
+        "error": null
     },
     "file813": {
         "data": [
@@ -13636,14 +14641,15 @@
         "lower_extreme": null,
         "upper_specification": 28.16,
         "lower_specification": 27.96,
-        "cp_point": 1.092089755191383,
-        "cpk_point": 0.9944700442863826,
+        "cp_point": 1.092,
+        "cpk_point": 0.994,
         "cp_interval": [
-            1.006236609697653, 1.185682130970314
+            1.006, 1.186
         ],
         "cpk_interval": [
-            0.8946522433859722, 1.0959530972962916
-        ]
+            0.895, 1.096
+        ],
+        "error": null
     },
     "file814": {
         "data": [
@@ -13653,14 +14659,15 @@
         "lower_extreme": null,
         "upper_specification": 44.025,
         "lower_specification": 44.009,
-        "cp_point": 1.0979796015326253,
-        "cpk_point": 1.007563480906035,
+        "cp_point": 1.098,
+        "cpk_point": 1.008,
         "cp_interval": [
-            1.022522430517635, 1.1687449778350014
+            1.023, 1.169
         ],
         "cpk_interval": [
-            0.9339273054879029, 1.086626986827945
-        ]
+            0.934, 1.087
+        ],
+        "error": null
     },
     "file815": {
         "data": [
@@ -13670,14 +14677,15 @@
         "lower_extreme": null,
         "upper_specification": 44.025,
         "lower_specification": 44.009,
-        "cp_point": 1.3446320519954058,
-        "cpk_point": 1.08711349061186,
+        "cp_point": 1.345,
+        "cpk_point": 1.087,
         "cp_interval": [
-            1.2576531761483662, 1.427499971589119
+            1.258, 1.427
         ],
         "cpk_interval": [
-            1.0027976194004427, 1.1648242586889181
-        ]
+            1.003, 1.165
+        ],
+        "error": null
     },
     "file816": {
         "data": [
@@ -13687,14 +14695,15 @@
         "lower_extreme": null,
         "upper_specification": 28.02,
         "lower_specification": 28.009,
-        "cp_point": 0.9978688901350489,
-        "cpk_point": 0.9878454266805021,
+        "cp_point": 0.998,
+        "cpk_point": 0.988,
         "cp_interval": [
-            0.9288361493206223, 1.0597122170802824
+            0.929, 1.06
         ],
         "cpk_interval": [
-            0.909648336764747, 1.0465658268601867
-        ]
+            0.91, 1.047
+        ],
+        "error": null
     },
     "file817": {
         "data": [
@@ -13704,14 +14713,15 @@
         "lower_extreme": null,
         "upper_specification": 28.02,
         "lower_specification": 28.009,
-        "cp_point": 1.140906037854391,
-        "cpk_point": 1.1405255497771292,
+        "cp_point": 1.141,
+        "cpk_point": 1.141,
         "cp_interval": [
-            1.0707385275032404, 1.1940519994614107
+            1.071, 1.194
         ],
         "cpk_interval": [
-            1.0453940473815582, 1.1786394445038308
-        ]
+            1.045, 1.179
+        ],
+        "error": null
     },
     "file818": {
         "data": [
@@ -13721,14 +14731,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.005,
         "lower_specification": null,
-        "cp_point": 0.9041654869763599,
-        "cpk_point": 0.8842429357326225,
+        "cp_point": 0.908,
+        "cpk_point": 0.884,
         "cp_interval": [
-            0.7888247124817747, 0.9961446981835046
+            0.792, 1.0
         ],
         "cpk_interval": [
-            0.7514572751621672, 0.9848874600797736
-        ]
+            0.751, 0.998
+        ],
+        "error": null
     },
     "file819": {
         "data": [
@@ -13738,14 +14749,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.005,
         "lower_specification": null,
-        "cp_point": 0.7908890218121705,
-        "cpk_point": 0.7401054960305986,
+        "cp_point": 0.794,
+        "cpk_point": 0.74,
         "cp_interval": [
-            0.6964618549100121, 0.867894716115867
+            0.699, 0.872
         ],
         "cpk_interval": [
-            0.6375270678781462, 0.8311093817313789
-        ]
+            0.638, 0.831
+        ],
+        "error": null
     },
     "file820": {
         "data": [
@@ -13755,14 +14767,15 @@
         "lower_extreme": null,
         "upper_specification": 28.16,
         "lower_specification": 27.96,
-        "cp_point": 1.0528188234250506,
-        "cpk_point": 1.013614960659105,
+        "cp_point": 1.053,
+        "cpk_point": 1.014,
         "cp_interval": [
-            0.969348803941108, 1.131138476373032
+            0.969, 1.131
         ],
         "cpk_interval": [
-            0.9293244694310729, 1.0773382424316138
-        ]
+            0.929, 1.077
+        ],
+        "error": null
     },
     "file821": {
         "data": [
@@ -13772,14 +14785,15 @@
         "lower_extreme": null,
         "upper_specification": 44.025,
         "lower_specification": 44.009,
-        "cp_point": 1.4680292368333916,
-        "cpk_point": 1.3832932451837439,
+        "cp_point": 1.468,
+        "cpk_point": 1.383,
         "cp_interval": [
-            1.3645152509339964, 1.561316567416982
+            1.365, 1.561
         ],
         "cpk_interval": [
-            1.2910522975198073, 1.473030541519133
-        ]
+            1.291, 1.473
+        ],
+        "error": null
     },
     "file822": {
         "data": [
@@ -13789,14 +14803,15 @@
         "lower_extreme": null,
         "upper_specification": 44.025,
         "lower_specification": 44.009,
-        "cp_point": 1.3286195367432156,
-        "cpk_point": 1.1164983744956478,
+        "cp_point": 1.329,
+        "cpk_point": 1.116,
         "cp_interval": [
-            1.2350335818139644, 1.4135382550686957
+            1.235, 1.414
         ],
         "cpk_interval": [
-            1.040546946467116, 1.1950690132686748
-        ]
+            1.041, 1.195
+        ],
+        "error": null
     },
     "file823": {
         "data": [
@@ -13806,14 +14821,15 @@
         "lower_extreme": null,
         "upper_specification": 28.02,
         "lower_specification": 28.009,
-        "cp_point": 1.099537355428415,
-        "cpk_point": 1.0524186006531993,
+        "cp_point": 1.1,
+        "cpk_point": 1.052,
         "cp_interval": [
-            1.0244700929053998, 1.1833062574503945
+            1.024, 1.183
         ],
         "cpk_interval": [
-            0.985660359268948, 1.1214428753633603
-        ]
+            0.986, 1.121
+        ],
+        "error": null
     },
     "file824": {
         "data": [
@@ -13823,14 +14839,15 @@
         "lower_extreme": null,
         "upper_specification": 28.02,
         "lower_specification": 28.009,
-        "cp_point": 0.9200824224328686,
-        "cpk_point": 0.8537503330991885,
+        "cp_point": 0.92,
+        "cpk_point": 0.854,
         "cp_interval": [
-            0.8527576636470255, 0.9812330490653886
+            0.853, 0.981
         ],
         "cpk_interval": [
-            0.8024925237033173, 0.9080389853063601
-        ]
+            0.802, 0.908
+        ],
+        "error": null
     },
     "file825": {
         "data": [
@@ -13840,14 +14857,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.005,
         "lower_specification": null,
-        "cp_point": 0.8584003361110996,
-        "cpk_point": 0.8372701723962147,
+        "cp_point": 0.861,
+        "cpk_point": 0.837,
         "cp_interval": [
-            0.7155186076417195, 0.9696880552826945
+            0.718, 0.973
         ],
         "cpk_interval": [
-            0.6828058194675034, 0.9667848761068746
-        ]
+            0.683, 0.967
+        ],
+        "error": null
     },
     "file826": {
         "data": [
@@ -13857,14 +14875,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.005,
         "lower_specification": null,
-        "cp_point": 1.0001438692453382,
-        "cpk_point": 0.9851902140374718,
+        "cp_point": 1.004,
+        "cpk_point": 1.004,
         "cp_interval": [
-            0.9027187012899489, 1.114702487500569
+            0.906, 1.119
         ],
         "cpk_interval": [
-            0.8844193592615398, 0.9887373802443858
-        ]
+            0.884, 1.149
+        ],
+        "error": null
     },
     "file827": {
         "data": [
@@ -13874,14 +14893,15 @@
         "lower_extreme": null,
         "upper_specification": 28.16,
         "lower_specification": 27.96,
-        "cp_point": 1.1738504218681671,
-        "cpk_point": 1.1506572039631158,
+        "cp_point": 1.174,
+        "cpk_point": 1.151,
         "cp_interval": [
-            1.0094731068837106, 1.2896083305814825
+            1.009, 1.29
         ],
         "cpk_interval": [
-            0.956677780990736, 1.2311301516230997
-        ]
+            0.957, 1.231
+        ],
+        "error": null
     },
     "file828": {
         "data": [
@@ -13891,14 +14911,15 @@
         "lower_extreme": null,
         "upper_specification": 44.025,
         "lower_specification": 44.009,
-        "cp_point": 0.5356582529467787,
-        "cpk_point": 0.3523953394120219,
+        "cp_point": 0.536,
+        "cpk_point": 0.352,
         "cp_interval": [
-            0.2864031163771848, 1.451003269704726
+            0.286, 1.451
         ],
         "cpk_interval": [
-            0.1719103645977717, 1.3997365673582507
-        ]
+            0.172, 1.4
+        ],
+        "error": null
     },
     "file829": {
         "data": [
@@ -13908,14 +14929,15 @@
         "lower_extreme": null,
         "upper_specification": 44.025,
         "lower_specification": 44.009,
-        "cp_point": 0.8014280020838886,
-        "cpk_point": 0.527709825851187,
+        "cp_point": 0.801,
+        "cpk_point": 0.528,
         "cp_interval": [
-            0.34799598919657554, 1.4064839262685045
+            0.348, 1.406
         ],
         "cpk_interval": [
-            0.21361368310957218, 1.222759597131756
-        ]
+            0.214, 1.223
+        ],
+        "error": null
     },
     "file830": {
         "data": [
@@ -13925,14 +14947,15 @@
         "lower_extreme": null,
         "upper_specification": 28.02,
         "lower_specification": 28.009,
-        "cp_point": 0.4990633950550175,
-        "cpk_point": 0.287148215184515,
+        "cp_point": 0.499,
+        "cpk_point": 0.287,
         "cp_interval": [
-            0.1692992316261378, 1.187553486053238
+            0.169, 1.188
         ],
         "cpk_interval": [
-            0.07845780120236354, 1.1678929253227404
-        ]
+            0.078, 1.168
+        ],
+        "error": null
     },
     "file831": {
         "data": [
@@ -13942,14 +14965,15 @@
         "lower_extreme": null,
         "upper_specification": 28.02,
         "lower_specification": 28.009,
-        "cp_point": 0.4906670003315428,
-        "cpk_point": 0.26995843470193975,
+        "cp_point": 0.491,
+        "cpk_point": 0.27,
         "cp_interval": [
-            0.2170619681111257, 1.1390667241406598
+            0.217, 1.139
         ],
         "cpk_interval": [
-            0.10208209865326438, 1.1145239731241698
-        ]
+            0.102, 1.115
+        ],
+        "error": null
     },
     "file832": {
         "data": [
@@ -13959,14 +14983,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.005,
         "lower_specification": null,
-        "cp_point": 0.5609694649520692,
-        "cpk_point": 0.49460406901445886,
+        "cp_point": 0.565,
+        "cpk_point": 0.495,
         "cp_interval": [
-            0.2571019405752375, 1.0250581046381728
+            0.259, 1.032
         ],
         "cpk_interval": [
-            0.20864059610304758, 0.9796857211005204
-        ]
+            0.209, 1.036
+        ],
+        "error": null
     },
     "file833": {
         "data": [
@@ -13976,14 +15001,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.005,
         "lower_specification": null,
-        "cp_point": 1.2231919234390984,
-        "cpk_point": 0.9856680380716476,
+        "cp_point": 1.227,
+        "cpk_point": 1.277,
         "cp_interval": [
-            1.0534619898417534, 1.33644385276488
+            1.056, 1.34
         ],
         "cpk_interval": [
-            0.9820252259868534, 0.9905664700989235
-        ]
+            1.068, 1.423
+        ],
+        "error": null
     },
     "file834": {
         "data": [
@@ -13993,14 +15019,15 @@
         "lower_extreme": null,
         "upper_specification": 28.16,
         "lower_specification": 27.96,
-        "cp_point": 1.1587900368252033,
-        "cpk_point": 1.0294899152848247,
+        "cp_point": 1.159,
+        "cpk_point": 1.029,
         "cp_interval": [
-            1.022187153198811, 1.2698939467440704
+            1.022, 1.27
         ],
         "cpk_interval": [
-            0.8865762421086141, 1.142530499190618
-        ]
+            0.887, 1.143
+        ],
+        "error": null
     },
     "file835": {
         "data": [
@@ -14010,14 +15037,15 @@
         "lower_extreme": null,
         "upper_specification": 44.025,
         "lower_specification": 44.009,
-        "cp_point": 0.27610520552224116,
-        "cpk_point": 0.13361473290193307,
+        "cp_point": 0.276,
+        "cpk_point": 0.134,
         "cp_interval": [
-            0.08156527586626276, 1.5804558824555788
+            0.082, 1.58
         ],
         "cpk_interval": [
-            0.039276680753536526, 1.2656942950171273
-        ]
+            0.039, 1.266
+        ],
+        "error": null
     },
     "file836": {
         "data": [
@@ -14027,14 +15055,15 @@
         "lower_extreme": null,
         "upper_specification": 44.025,
         "lower_specification": 44.009,
-        "cp_point": 0.22733870122381167,
-        "cpk_point": 0.10876115940804097,
+        "cp_point": 0.227,
+        "cpk_point": 0.109,
         "cp_interval": [
-            0.06779531168962305, 1.486601725984632
+            0.068, 1.487
         ],
         "cpk_interval": [
-            0.030302467696477105, 1.1927232160262806
-        ]
+            0.03, 1.193
+        ],
+        "error": null
     },
     "file837": {
         "data": [
@@ -14044,14 +15073,15 @@
         "lower_extreme": null,
         "upper_specification": 28.02,
         "lower_specification": 28.009,
-        "cp_point": 0.09725751866644011,
-        "cpk_point": 0.045449919493383895,
+        "cp_point": 0.097,
+        "cpk_point": 0.045,
         "cp_interval": [
-            0.017236431013534642, 1.1784219191632426
+            0.017, 1.178
         ],
         "cpk_interval": [
-            0.007886667605329434, 1.1663218769622077
-        ]
+            0.008, 1.166
+        ],
+        "error": null
     },
     "file838": {
         "data": [
@@ -14061,14 +15091,15 @@
         "lower_extreme": null,
         "upper_specification": 28.02,
         "lower_specification": 28.009,
-        "cp_point": 0.2752691904583188,
-        "cpk_point": 0.12263578683899348,
+        "cp_point": 0.275,
+        "cpk_point": 0.123,
         "cp_interval": [
-            0.12734022073032927, 1.028055799168651
+            0.127, 1.028
         ],
         "cpk_interval": [
-            0.05137659903194453, 0.9193211113635381
-        ]
+            0.051, 0.919
+        ],
+        "error": null
     },
     "file839": {
         "data": [
@@ -14078,14 +15109,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.005,
         "lower_specification": null,
-        "cp_point": 0.41710747485085603,
-        "cpk_point": 0.379869106779583,
+        "cp_point": 0.419,
+        "cpk_point": 0.38,
         "cp_interval": [
-            0.03032661601880858, 0.9390865470551054
+            0.03, 0.942
         ],
         "cpk_interval": [
-            0.02618717284956737, 0.9319066187591307
-        ]
+            0.026, 0.932
+        ],
+        "error": null
     },
     "file840": {
         "data": [
@@ -14095,14 +15127,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.005,
         "lower_specification": null,
-        "cp_point": 0.06817550336452113,
-        "cpk_point": 0.055133904859315165,
+        "cp_point": 0.068,
+        "cpk_point": 0.055,
         "cp_interval": [
-            0.010906510204724168, 0.966771272274982
+            0.011, 0.971
         ],
         "cpk_interval": [
-            0.00922925341839715, 0.9628484963134187
-        ]
+            0.009, 0.963
+        ],
+        "error": null
     },
     "file841": {
         "data": [
@@ -14112,14 +15145,15 @@
         "lower_extreme": null,
         "upper_specification": 28.16,
         "lower_specification": 27.96,
-        "cp_point": 0.31896999715091146,
-        "cpk_point": 0.17340615855921743,
+        "cp_point": 0.319,
+        "cpk_point": 0.173,
         "cp_interval": [
-            0.07136685262097743, 1.0510350907207149
+            0.071, 1.051
         ],
         "cpk_interval": [
-            0.03484419470954277, 0.8600186162048994
-        ]
+            0.035, 0.86
+        ],
+        "error": null
     },
     "file842": {
         "data": [
@@ -14129,14 +15163,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.1832425950462788,
-        "cpk_point": 1.1669328972343602,
+        "cp_point": 1.183,
+        "cpk_point": 1.167,
         "cp_interval": [
-            1.0227861716319895, 1.338610531692525
+            1.023, 1.339
         ],
         "cpk_interval": [
-            0.9693264808808995, 1.2788854091806898
-        ]
+            0.969, 1.279
+        ],
+        "error": null
     },
     "file843": {
         "data": [
@@ -14146,14 +15181,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.2184450650986176,
-        "cpk_point": 0.9020560331785017,
+        "cp_point": 1.218,
+        "cpk_point": 0.902,
         "cp_interval": [
-            1.0146382135004308, 1.3964955190572343
+            1.015, 1.396
         ],
         "cpk_interval": [
-            0.7215654666612313, 1.04068176817247
-        ]
+            0.722, 1.041
+        ],
+        "error": null
     },
     "file844": {
         "data": [
@@ -14163,14 +15199,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": 2.0,
-        "cp_point": 0.8041273360992576,
-        "cpk_point": 0.5628445438233219,
+        "cp_point": 0.804,
+        "cpk_point": 0.563,
         "cp_interval": [
-            0.6870373331559889, 0.9014221509247713
+            0.687, 0.901
         ],
         "cpk_interval": [
-            0.41514533196414394, 0.6595511175705083
-        ]
+            0.415, 0.66
+        ],
+        "error": null
     },
     "file845": {
         "data": [
@@ -14180,14 +15217,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": 2.0,
-        "cp_point": 0.5092955229848463,
-        "cpk_point": 0.49253404763166225,
+        "cp_point": 0.509,
+        "cpk_point": 0.493,
         "cp_interval": [
-            0.4169368393851876, 0.5952867454585434
+            0.417, 0.595
         ],
         "cpk_interval": [
-            0.38247829690341556, 0.5713768974214634
-        ]
+            0.382, 0.571
+        ],
+        "error": null
     },
     "file846": {
         "data": [
@@ -14197,14 +15235,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": -6.0,
-        "cp_point": 1.7599585992337283,
-        "cpk_point": 1.5100547901739514,
+        "cp_point": 1.76,
+        "cpk_point": 1.51,
         "cp_interval": [
-            1.474857878796192, 2.0128351836341336
+            1.475, 2.013
         ],
         "cpk_interval": [
-            1.2303570727208997, 1.7942999524575807
-        ]
+            1.23, 1.794
+        ],
+        "error": null
     },
     "file847": {
         "data": [
@@ -14214,14 +15253,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": -6.0,
-        "cp_point": 1.239549475575136,
-        "cpk_point": 0.8444884910655649,
+        "cp_point": 1.24,
+        "cpk_point": 0.844,
         "cp_interval": [
-            0.8859724636766474, 1.5645697236410032
+            0.886, 1.565
         ],
         "cpk_interval": [
-            0.5376801571067006, 1.1629647136189523
-        ]
+            0.538, 1.163
+        ],
+        "error": null
     },
     "file848": {
         "data": [
@@ -14231,14 +15271,15 @@
         "lower_extreme": null,
         "upper_specification": -6.0,
         "lower_specification": -24.0,
-        "cp_point": 1.3357589020029423,
-        "cpk_point": 1.0628373233458055,
+        "cp_point": 1.336,
+        "cpk_point": 1.063,
         "cp_interval": [
-            1.172493040093661, 1.4711216629603596
+            1.172, 1.471
         ],
         "cpk_interval": [
-            0.8811672506935736, 1.203239636349682
-        ]
+            0.881, 1.203
+        ],
+        "error": null
     },
     "file849": {
         "data": [
@@ -14248,14 +15289,15 @@
         "lower_extreme": null,
         "upper_specification": -6.0,
         "lower_specification": -24.0,
-        "cp_point": 1.4870485095538102,
-        "cpk_point": 1.0999374956832355,
+        "cp_point": 1.487,
+        "cpk_point": 1.1,
         "cp_interval": [
-            1.3056333459272695, 1.6418794365427343
+            1.306, 1.642
         ],
         "cpk_interval": [
-            0.9417585331715818, 1.2907519865817085
-        ]
+            0.942, 1.291
+        ],
+        "error": null
     },
     "file850": {
         "data": [
@@ -14265,14 +15307,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.5462492627813615,
-        "cpk_point": 0.339700771977323,
+        "cp_point": 0.728,
+        "cpk_point": 0.34,
         "cp_interval": [
-            0.3877294555856145, 0.6898480717147886
+            0.517, 0.92
         ],
         "cpk_interval": [
-            0.2251856716693601, 0.45706137573205763
-        ]
+            0.225, 0.457
+        ],
+        "error": null
     },
     "file851": {
         "data": [
@@ -14282,14 +15325,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 0.20134892254612224,
-        "cpk_point": 0.175445011665287,
+        "cp_point": 0.205,
+        "cpk_point": 0.175,
         "cp_interval": [
-            0.10855444267844756, 0.3273397597845686
+            0.11, 0.333
         ],
         "cpk_interval": [
-            0.09167596656561046, 0.29047604255592724
-        ]
+            0.092, 0.29
+        ],
+        "error": null
     },
     "file852": {
         "data": [
@@ -14299,14 +15343,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.5397892198707969,
-        "cpk_point": 0.3964946616135147,
+        "cp_point": 0.67,
+        "cpk_point": 0.396,
         "cp_interval": [
-            0.41313643198254574, 0.6770305309809348
+            0.513, 0.84
         ],
         "cpk_interval": [
-            0.26698107835588436, 0.5769828318765412
-        ]
+            0.267, 0.577
+        ],
+        "error": null
     },
     "file853": {
         "data": [
@@ -14316,14 +15361,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 0.19032900967386712,
-        "cpk_point": 0.16331999488399285,
+        "cp_point": 0.193,
+        "cpk_point": 0.163,
         "cp_interval": [
-            0.10116247222166244, 0.3106593026147343
+            0.103, 0.316
         ],
         "cpk_interval": [
-            0.08468907186939309, 0.27313352566340016
-        ]
+            0.085, 0.273
+        ],
+        "error": null
     },
     "file854": {
         "data": [
@@ -14333,14 +15379,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 0.20195058963093399,
-        "cpk_point": 0.16449210309290185,
+        "cp_point": 0.209,
+        "cpk_point": 0.164,
         "cp_interval": [
-            0.09952189130251043, 0.31341501905064584
+            0.103, 0.324
         ],
         "cpk_interval": [
-            0.07590435375396734, 0.2647348267260424
-        ]
+            0.076, 0.265
+        ],
+        "error": null
     },
     "file855": {
         "data": [
@@ -14350,14 +15397,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.5288238331624775,
-        "cpk_point": 0.8836742254086684,
+        "cp_point": 1.709,
+        "cpk_point": 2.03,
         "cp_interval": [
-            1.3682768745301803, 1.6959894381764575
+            1.529, 1.896
         ],
         "cpk_interval": [
-            0.7877056104703003, 0.9570928671245142
-        ]
+            1.702, 2.405
+        ],
+        "error": null
     },
     "file856": {
         "data": [
@@ -14367,14 +15415,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.1472713911231975,
-        "cpk_point": 0.81591607638047,
+        "cp_point": 1.29,
+        "cpk_point": 1.403,
         "cp_interval": [
-            0.9803480674546223, 1.3389905667138087
+            1.102, 1.505
         ],
         "cpk_interval": [
-            0.7533870219563081, 0.8901695037332842
-        ]
+            1.12, 1.749
+        ],
+        "error": null
     },
     "file857": {
         "data": [
@@ -14384,14 +15433,15 @@
         "lower_extreme": null,
         "upper_specification": 59.81,
         "lower_specification": 59.56,
-        "cp_point": 1.0567241012987652,
-        "cpk_point": 0.7173901470923439,
+        "cp_point": 1.057,
+        "cpk_point": 0.717,
         "cp_interval": [
-            0.8704286614554019, 1.2265288200242441
+            0.87, 1.227
         ],
         "cpk_interval": [
-            0.5687990337155593, 0.8868651960551611
-        ]
+            0.569, 0.887
+        ],
+        "error": null
     },
     "file858": {
         "data": [
@@ -14401,14 +15451,15 @@
         "lower_extreme": null,
         "upper_specification": 73.95,
         "lower_specification": 73.75,
-        "cp_point": 1.34611986596252,
-        "cpk_point": 0.9885506322908253,
+        "cp_point": 1.346,
+        "cpk_point": 0.989,
         "cp_interval": [
-            1.1301072657716473, 1.5342525389295616
+            1.13, 1.534
         ],
         "cpk_interval": [
-            0.8029308609006087, 1.1295679244726191
-        ]
+            0.803, 1.13
+        ],
+        "error": null
     },
     "file859": {
         "data": [
@@ -14418,14 +15469,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.19888502148347498,
-        "cpk_point": 0.15933236192516853,
+        "cp_point": 0.209,
+        "cpk_point": 0.159,
         "cp_interval": [
-            0.10393815071458337, 0.32895882529595766
+            0.109, 0.346
         ],
         "cpk_interval": [
-            0.08139883077718822, 0.278013906237796
-        ]
+            0.081, 0.278
+        ],
+        "error": null
     },
     "file860": {
         "data": [
@@ -14435,14 +15487,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.15696804533849298,
-        "cpk_point": 0.12513922212716994,
+        "cp_point": 0.162,
+        "cpk_point": 0.125,
         "cp_interval": [
-            0.08027631829754275, 0.27481941917096575
+            0.083, 0.284
         ],
         "cpk_interval": [
-            0.06191504323023612, 0.2280929053985971
-        ]
+            0.062, 0.228
+        ],
+        "error": null
     },
     "file861": {
         "data": [
@@ -14452,14 +15505,15 @@
         "lower_extreme": null,
         "upper_specification": 71.037,
         "lower_specification": 70.978,
-        "cp_point": 0.6630443311021765,
-        "cpk_point": 0.1832438869376974,
+        "cp_point": 0.663,
+        "cpk_point": 0.183,
         "cp_interval": [
-            0.5452423516787406, 0.774511860535546
+            0.545, 0.775
         ],
         "cpk_interval": [
-            0.13042446814852593, 0.25733796936004044
-        ]
+            0.13, 0.257
+        ],
+        "error": null
     },
     "file862": {
         "data": [
@@ -14469,14 +15523,15 @@
         "lower_extreme": null,
         "upper_specification": 71.037,
         "lower_specification": 70.978,
-        "cp_point": 0.6659120699957951,
-        "cpk_point": 0.16421396300793373,
+        "cp_point": 0.666,
+        "cpk_point": 0.164,
         "cp_interval": [
-            0.5487850258025797, 0.7764260168920922
+            0.549, 0.776
         ],
         "cpk_interval": [
-            0.11294988474990844, 0.23442698451367647
-        ]
+            0.113, 0.234
+        ],
+        "error": null
     },
     "file863": {
         "data": [
@@ -14486,14 +15541,15 @@
         "lower_extreme": null,
         "upper_specification": 71.037,
         "lower_specification": 70.978,
-        "cp_point": 0.6595260541650545,
-        "cpk_point": 0.20027278757488948,
+        "cp_point": 0.66,
+        "cpk_point": 0.2,
         "cp_interval": [
-            0.5411824766808222, 0.7718152913110473
+            0.541, 0.772
         ],
         "cpk_interval": [
-            0.1455249133713326, 0.27532229404818925
-        ]
+            0.146, 0.275
+        ],
+        "error": null
     },
     "file864": {
         "data": [
@@ -14503,14 +15559,15 @@
         "lower_extreme": null,
         "upper_specification": -6.0,
         "lower_specification": -24.0,
-        "cp_point": 0.47203158723383926,
-        "cpk_point": 0.4682827740675595,
+        "cp_point": 0.472,
+        "cpk_point": 0.468,
         "cp_interval": [
-            0.3903816137085527, 0.5460111633658378
+            0.39, 0.546
         ],
         "cpk_interval": [
-            0.36468903497949917, 0.5108749263381996
-        ]
+            0.365, 0.511
+        ],
+        "error": null
     },
     "file865": {
         "data": [
@@ -14520,14 +15577,15 @@
         "lower_extreme": null,
         "upper_specification": -6.0,
         "lower_specification": -24.0,
-        "cp_point": 0.5172726032242874,
-        "cpk_point": 0.37290905739326907,
+        "cp_point": 0.517,
+        "cpk_point": 0.373,
         "cp_interval": [
-            0.3694452569339605, 0.568542175596208
+            0.369, 0.569
         ],
         "cpk_interval": [
-            0.23948305690444563, 0.4449899491478069
-        ]
+            0.239, 0.445
+        ],
+        "error": null
     },
     "file866": {
         "data": [
@@ -14537,14 +15595,15 @@
         "lower_extreme": null,
         "upper_specification": -6.0,
         "lower_specification": -24.0,
-        "cp_point": 0.43856782036845876,
-        "cpk_point": 0.34356156574181157,
+        "cp_point": 0.439,
+        "cpk_point": 0.344,
         "cp_interval": [
-            0.09635520058426676, 0.5569609546399547
+            0.096, 0.557
         ],
         "cpk_interval": [
-            0.05974095338753228, 0.47446946844940474
-        ]
+            0.06, 0.474
+        ],
+        "error": null
     },
     "file867": {
         "data": [
@@ -14554,14 +15613,15 @@
         "lower_extreme": null,
         "upper_specification": -6.0,
         "lower_specification": -24.0,
-        "cp_point": 0.44000953080667093,
-        "cpk_point": 0.13778060110968676,
+        "cp_point": 0.44,
+        "cpk_point": 0.138,
         "cp_interval": [
-            0.32400065874747136, 0.5498666576269937
+            0.324, 0.55
         ],
         "cpk_interval": [
-            0.08354763538920225, 0.19042342095692458
-        ]
+            0.084, 0.19
+        ],
+        "error": null
     },
     "file868": {
         "data": [
@@ -14571,14 +15631,15 @@
         "lower_extreme": null,
         "upper_specification": 26.0,
         "lower_specification": 14.0,
-        "cp_point": 2.133754284454572,
-        "cpk_point": 1.162838729819353,
+        "cp_point": 2.134,
+        "cpk_point": 1.163,
         "cp_interval": [
-            1.8069101972968167, 2.416837365909126
+            1.807, 2.417
         ],
         "cpk_interval": [
-            0.9623979737849582, 1.3249969011032647
-        ]
+            0.962, 1.325
+        ],
+        "error": null
     },
     "file869": {
         "data": [
@@ -14588,14 +15649,15 @@
         "lower_extreme": null,
         "upper_specification": 26.0,
         "lower_specification": 14.0,
-        "cp_point": 1.786525968760019,
-        "cpk_point": 1.3881881580869817,
+        "cp_point": 1.787,
+        "cpk_point": 1.388,
         "cp_interval": [
-            1.5151929319897097, 2.0212830917566156
+            1.515, 2.021
         ],
         "cpk_interval": [
-            1.1511756572243168, 1.5796157248333322
-        ]
+            1.151, 1.58
+        ],
+        "error": null
     },
     "file870": {
         "data": [
@@ -14605,14 +15667,15 @@
         "lower_extreme": null,
         "upper_specification": -11.0,
         "lower_specification": -29.0,
-        "cp_point": 0.5609617832240426,
-        "cpk_point": 0.19797497478420187,
+        "cp_point": 0.561,
+        "cpk_point": 0.198,
         "cp_interval": [
-            0.4817284257973062, 0.6327037240520021
+            0.482, 0.633
         ],
         "cpk_interval": [
-            0.1411759987921794, 0.2678095556437416
-        ]
+            0.141, 0.268
+        ],
+        "error": null
     },
     "file871": {
         "data": [
@@ -14622,14 +15685,15 @@
         "lower_extreme": null,
         "upper_specification": 10.0,
         "lower_specification": 2.0,
-        "cp_point": 1.0075431869201292,
-        "cpk_point": 0.5167579869884349,
+        "cp_point": 1.008,
+        "cpk_point": 0.517,
         "cp_interval": [
-            0.8656804828356521, 1.1366873790239176
+            0.866, 1.137
         ],
         "cpk_interval": [
-            0.42395155065798173, 0.6229375186306468
-        ]
+            0.424, 0.623
+        ],
+        "error": null
     },
     "file872": {
         "data": [
@@ -14639,14 +15703,15 @@
         "lower_extreme": null,
         "upper_specification": -11.0,
         "lower_specification": -29.0,
-        "cp_point": 0.38173691560503836,
-        "cpk_point": -0.29266978234961577,
+        "cp_point": 0.382,
+        "cpk_point": -0.293,
         "cp_interval": [
-            0.3044951426961885, 0.4544329007982612
+            0.304, 0.454
         ],
         "cpk_interval": [
-            -0.39347127656069136, -0.2165585946337672
-        ]
+            -0.393, -0.217
+        ],
+        "error": null
     },
     "file873": {
         "data": [
@@ -14656,14 +15721,15 @@
         "lower_extreme": null,
         "upper_specification": 10.0,
         "lower_specification": 2.0,
-        "cp_point": 0.7145927107265607,
-        "cpk_point": 0.395310273690467,
+        "cp_point": 0.715,
+        "cpk_point": 0.395,
         "cp_interval": [
-            0.44433314967160537, 0.8696494078146603
+            0.444, 0.87
         ],
         "cpk_interval": [
-            0.22340155272976037, 0.5105294414619996
-        ]
+            0.223, 0.511
+        ],
+        "error": null
     },
     "file874": {
         "data": [
@@ -14673,14 +15739,15 @@
         "lower_extreme": null,
         "upper_specification": -1.0,
         "lower_specification": -19.0,
-        "cp_point": 0.36294885895223533,
-        "cpk_point": 0.3332301720214841,
+        "cp_point": 0.363,
+        "cpk_point": 0.333,
         "cp_interval": [
-            0.31260695072589584, 0.4099504782937394
+            0.313, 0.41
         ],
         "cpk_interval": [
-            0.26650533826568856, 0.393502524232247
-        ]
+            0.267, 0.394
+        ],
+        "error": null
     },
     "file875": {
         "data": [
@@ -14690,14 +15757,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.5416267230180665,
-        "cpk_point": 0.36106158766409796,
+        "cp_point": 1.542,
+        "cpk_point": 0.361,
         "cp_interval": [
-            1.367041470222619, 1.6666624426664498
+            1.367, 1.667
         ],
         "cpk_interval": [
-            0.2528680210898717, 0.4735402387806843
-        ]
+            0.253, 0.474
+        ],
+        "error": null
     },
     "file876": {
         "data": [
@@ -14707,14 +15775,15 @@
         "lower_extreme": null,
         "upper_specification": -1.0,
         "lower_specification": -19.0,
-        "cp_point": 0.4248255757319583,
-        "cpk_point": 0.29062899860749974,
+        "cp_point": 0.425,
+        "cpk_point": 0.291,
         "cp_interval": [
-            0.3619831433433842, 0.4828615903959258
+            0.362, 0.483
         ],
         "cpk_interval": [
-            0.20559654671568522, 0.3539250057471311
-        ]
+            0.206, 0.354
+        ],
+        "error": null
     },
     "file877": {
         "data": [
@@ -14724,14 +15793,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.355297907872951,
-        "cpk_point": 0.8623225101081035,
+        "cp_point": 1.355,
+        "cpk_point": 0.862,
         "cp_interval": [
-            1.1572462216624166, 1.4845245801895084
+            1.157, 1.485
         ],
         "cpk_interval": [
-            0.718785234427739, 1.0007413892497048
-        ]
+            0.719, 1.001
+        ],
+        "error": null
     },
     "file878": {
         "data": [
@@ -14741,14 +15811,15 @@
         "lower_extreme": null,
         "upper_specification": 11.0,
         "lower_specification": 5.0,
-        "cp_point": 1.2411608149374482,
-        "cpk_point": 1.217242575923081,
+        "cp_point": 1.241,
+        "cpk_point": 1.217,
         "cp_interval": [
-            1.0514810711387685, 1.4480294461779972
+            1.051, 1.448
         ],
         "cpk_interval": [
-            1.0199887860859462, 1.3756701637209436
-        ]
+            1.02, 1.376
+        ],
+        "error": null
     },
     "file879": {
         "data": [
@@ -14758,14 +15829,15 @@
         "lower_extreme": null,
         "upper_specification": 11.0,
         "lower_specification": 5.0,
-        "cp_point": 0.9025710881957415,
-        "cpk_point": 0.8879440509931396,
+        "cp_point": 0.903,
+        "cpk_point": 0.888,
         "cp_interval": [
-            0.7550824618856731, 1.0325865172851387
+            0.755, 1.033
         ],
         "cpk_interval": [
-            0.7325934221282127, 0.9707125567101927
-        ]
+            0.733, 0.971
+        ],
+        "error": null
     },
     "file880": {
         "data": [
@@ -14775,14 +15847,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.6110333838098287,
-        "cpk_point": 0.8942306386570807,
+        "cp_point": 1.687,
+        "cpk_point": 1.946,
         "cp_interval": [
-            1.4128729213013895, 1.804340127866765
+            1.48, 1.89
         ],
         "cpk_interval": [
-            0.8449222933362794, 0.9358809137403639
-        ]
+            1.644, 2.245
+        ],
+        "error": null
     },
     "file881": {
         "data": [
@@ -14792,14 +15865,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.3592220084605506,
-        "cpk_point": 0.8871921875912623,
+        "cp_point": 1.421,
+        "cpk_point": 1.574,
         "cp_interval": [
-            1.192997181251514, 1.5234652274944973
+            1.248, 1.593
         ],
         "cpk_interval": [
-            0.846545747996065, 0.9246421640879153
-        ]
+            1.328, 1.825
+        ],
+        "error": null
     },
     "file882": {
         "data": [
@@ -14809,14 +15883,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 0.6802928537001469,
-        "cpk_point": 0.6279930299903858,
+        "cp_point": 0.739,
+        "cpk_point": 0.628,
         "cp_interval": [
-            0.5707420168785525, 0.7935383280963232
+            0.62, 0.862
         ],
         "cpk_interval": [
-            0.5054914374276643, 0.7707979853956937
-        ]
+            0.505, 0.771
+        ],
+        "error": null
     },
     "file883": {
         "data": [
@@ -14826,14 +15901,15 @@
         "lower_extreme": null,
         "upper_specification": 40.55,
         "lower_specification": 40.3,
-        "cp_point": 1.6856867048252318,
-        "cpk_point": 0.7704112380396713,
+        "cp_point": 1.686,
+        "cpk_point": 0.77,
         "cp_interval": [
-            1.1863624195998403, 1.8786679390447398
+            1.186, 1.879
         ],
         "cpk_interval": [
-            0.4960240514951015, 0.9360191225799321
-        ]
+            0.496, 0.936
+        ],
+        "error": null
     },
     "file884": {
         "data": [
@@ -14843,14 +15919,15 @@
         "lower_extreme": null,
         "upper_specification": 55.1,
         "lower_specification": 54.9,
-        "cp_point": 1.8937885768999296,
-        "cpk_point": 1.7138373895804888,
+        "cp_point": 1.894,
+        "cpk_point": 1.714,
         "cp_interval": [
-            1.6818707558515498, 2.053978772091666
+            1.682, 2.054
         ],
         "cpk_interval": [
-            1.5175715769566556, 1.9066999962894866
-        ]
+            1.518, 1.907
+        ],
+        "error": null
     },
     "file885": {
         "data": [
@@ -14860,14 +15937,15 @@
         "lower_extreme": null,
         "upper_specification": 51.898,
         "lower_specification": 51.856,
-        "cp_point": 0.1875121522037354,
-        "cpk_point": 0.14971038403559947,
+        "cp_point": 0.188,
+        "cpk_point": 0.15,
         "cp_interval": [
-            0.05128828779722351, 0.39947650856302647
+            0.051, 0.399
         ],
         "cpk_interval": [
-            0.033653144383741396, 0.3563071868713168
-        ]
+            0.034, 0.356
+        ],
+        "error": null
     },
     "file886": {
         "data": [
@@ -14877,14 +15955,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": -6.0,
-        "cp_point": 2.1848463618664424,
-        "cpk_point": 2.08685116276123,
+        "cp_point": 2.185,
+        "cpk_point": 2.087,
         "cp_interval": [
-            1.9193496948693258, 2.419549961774083
+            1.919, 2.42
         ],
         "cpk_interval": [
-            1.7963753256997288, 2.3424884046680274
-        ]
+            1.796, 2.342
+        ],
+        "error": null
     },
     "file887": {
         "data": [
@@ -14894,14 +15973,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": -6.0,
-        "cp_point": 1.6489110496931323,
-        "cpk_point": 1.3470108271773922,
+        "cp_point": 1.649,
+        "cpk_point": 1.347,
         "cp_interval": [
-            1.4136094122485519, 1.9036914596001513
+            1.414, 1.904
         ],
         "cpk_interval": [
-            1.1265300212497626, 1.6018821848525606
-        ]
+            1.127, 1.602
+        ],
+        "error": null
     },
     "file888": {
         "data": [
@@ -14911,14 +15991,15 @@
         "lower_extreme": null,
         "upper_specification": -11.0,
         "lower_specification": -29.0,
-        "cp_point": 0.9390518060692687,
-        "cpk_point": 0.8757457351692125,
+        "cp_point": 0.939,
+        "cpk_point": 0.876,
         "cp_interval": [
-            0.8142659416550128, 1.0509471766372744
+            0.814, 1.051
         ],
         "cpk_interval": [
-            0.7431481258166819, 1.024044943032188
-        ]
+            0.743, 1.024
+        ],
+        "error": null
     },
     "file889": {
         "data": [
@@ -14928,14 +16009,15 @@
         "lower_extreme": null,
         "upper_specification": -1.0,
         "lower_specification": -19.0,
-        "cp_point": 0.606374714089354,
-        "cpk_point": 0.38338598632342114,
+        "cp_point": 0.606,
+        "cpk_point": 0.383,
         "cp_interval": [
-            0.4378795564070316, 0.7009572045868142
+            0.438, 0.701
         ],
         "cpk_interval": [
-            0.2547139488210096, 0.4827339561117739
-        ]
+            0.255, 0.483
+        ],
+        "error": null
     },
     "file890": {
         "data": [
@@ -14945,14 +16027,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 1.094625472694629,
-        "cpk_point": 0.8544325511457114,
+        "cp_point": 1.327,
+        "cpk_point": 1.265,
         "cp_interval": [
-            0.9315305888476035, 1.1536143916103563
+            1.13, 1.399
         ],
         "cpk_interval": [
-            0.7696946776597327, 0.9200165324082693
-        ]
+            1.013, 1.344
+        ],
+        "error": null
     },
     "file891": {
         "data": [
@@ -14962,14 +16045,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.8862777493552735,
-        "cpk_point": 0.8279521143820898,
+        "cp_point": 1.075,
+        "cpk_point": 0.92,
         "cp_interval": [
-            0.7441908668914412, 1.0080529701068206
+            0.903, 1.223
         ],
         "cpk_interval": [
-            0.7012086166618939, 0.8878081980469759
-        ]
+            0.715, 1.1
+        ],
+        "error": null
     },
     "file892": {
         "data": [
@@ -14979,14 +16063,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.277714004635984,
-        "cpk_point": 0.7814765718359331,
+        "cp_point": 1.452,
+        "cpk_point": 1.772,
         "cp_interval": [
-            1.0003971651485293, 1.5356452997925614
+            1.137, 1.745
         ],
         "cpk_interval": [
-            0.7138123221229091, 0.8728248333176118
-        ]
+            1.183, 2.357
+        ],
+        "error": null
     },
     "file893": {
         "data": [
@@ -14996,14 +16081,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.1185405112191988,
-        "cpk_point": 0.8090429907496606,
+        "cp_point": 1.25,
+        "cpk_point": 1.221,
         "cp_interval": [
-            0.901095865558682, 1.301138388931925
+            1.007, 1.454
         ],
         "cpk_interval": [
-            0.7454447778547431, 0.8684536541464888
-        ]
+            0.935, 1.5
+        ],
+        "error": null
     },
     "file894": {
         "data": [
@@ -15013,14 +16099,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.851791267942743,
-        "cpk_point": 0.8054902991346589,
+        "cp_point": 0.953,
+        "cpk_point": 0.877,
         "cp_interval": [
-            0.7548381193900424, 0.9452978218918391
+            0.845, 1.058
         ],
         "cpk_interval": [
-            0.744212064348486, 0.8442923693167298
-        ]
+            0.746, 1.023
+        ],
+        "error": null
     },
     "file895": {
         "data": [
@@ -15030,14 +16117,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.7872260700560226,
-        "cpk_point": 0.7760366766325167,
+        "cp_point": 0.881,
+        "cpk_point": 0.776,
         "cp_interval": [
-            0.6969606605758049, 0.8749751485193049
+            0.78, 0.98
         ],
         "cpk_interval": [
-            0.6561695609428603, 0.8375941599459187
-        ]
+            0.656, 0.91
+        ],
+        "error": null
     },
     "file896": {
         "data": [
@@ -15047,14 +16135,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 20.0,
         "lower_specification": null,
-        "cp_point": 0.4379781204809937,
-        "cpk_point": 0.27252976310424876,
+        "cp_point": 0.48,
+        "cpk_point": 0.273,
         "cp_interval": [
-            0.3646303177923905, 0.5111281810517853
+            0.4, 0.56
         ],
         "cpk_interval": [
-            0.17902657713298278, 0.36139786864396517
-        ]
+            0.179, 0.361
+        ],
+        "error": null
     },
     "file897": {
         "data": [
@@ -15064,14 +16153,15 @@
         "lower_extreme": null,
         "upper_specification": 41.94,
         "lower_specification": 41.67,
-        "cp_point": 2.3125899131501626,
-        "cpk_point": 2.042335229900781,
+        "cp_point": 2.313,
+        "cpk_point": 2.042,
         "cp_interval": [
-            1.9992428421305706, 2.6059552145979548
+            1.999, 2.606
         ],
         "cpk_interval": [
-            1.7487284646118872, 2.3105131145391136
-        ]
+            1.749, 2.311
+        ],
+        "error": null
     },
     "file898": {
         "data": [
@@ -15081,14 +16171,15 @@
         "lower_extreme": null,
         "upper_specification": 53.0,
         "lower_specification": 52.85,
-        "cp_point": 1.0765170895097644,
-        "cpk_point": 0.666662315140188,
+        "cp_point": 1.077,
+        "cpk_point": 0.667,
         "cp_interval": [
-            0.9299739113725543, 1.2142277599757956
+            0.93, 1.214
         ],
         "cpk_interval": [
-            0.5617645029257985, 0.7505382618573812
-        ]
+            0.562, 0.751
+        ],
+        "error": null
     },
     "file899": {
         "data": [
@@ -15098,14 +16189,15 @@
         "lower_extreme": null,
         "upper_specification": 50.122,
         "lower_specification": 50.077,
-        "cp_point": 0.46437552142448457,
-        "cpk_point": 0.35897372012731577,
+        "cp_point": 0.464,
+        "cpk_point": 0.359,
         "cp_interval": [
-            0.37466401767163066, 0.5330567243679936
+            0.375, 0.533
         ],
         "cpk_interval": [
-            0.2581011420882845, 0.45402503534982225
-        ]
+            0.258, 0.454
+        ],
+        "error": null
     },
     "file900": {
         "data": [
@@ -15115,14 +16207,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": -5.0,
-        "cp_point": 1.0282818078670468,
-        "cpk_point": 0.8757286203597298,
+        "cp_point": 1.028,
+        "cpk_point": 0.876,
         "cp_interval": [
-            0.2636605490085433, 1.621525037915779
+            0.264, 1.622
         ],
         "cpk_interval": [
-            0.16508597373000916, 1.4998160163434737
-        ]
+            0.165, 1.5
+        ],
+        "error": null
     },
     "file901": {
         "data": [
@@ -15132,14 +16225,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": -5.0,
-        "cp_point": 2.096748219403438,
-        "cpk_point": 2.020746602477945,
+        "cp_point": 2.097,
+        "cpk_point": 2.021,
         "cp_interval": [
-            1.789616383644342, 2.2847374488105205
+            1.79, 2.285
         ],
         "cpk_interval": [
-            1.6907459302925296, 2.213276291088894
-        ]
+            1.691, 2.213
+        ],
+        "error": null
     },
     "file902": {
         "data": [
@@ -15149,14 +16243,15 @@
         "lower_extreme": null,
         "upper_specification": -21.0,
         "lower_specification": -39.0,
-        "cp_point": 1.6480889245370025,
-        "cpk_point": 0.9805326971533892,
+        "cp_point": 1.648,
+        "cpk_point": 0.981,
         "cp_interval": [
-            1.4273711139463596, 1.8559155447414037
+            1.427, 1.856
         ],
         "cpk_interval": [
-            0.8431480744647858, 1.128106557456278
-        ]
+            0.843, 1.128
+        ],
+        "error": null
     },
     "file903": {
         "data": [
@@ -15166,14 +16261,15 @@
         "lower_extreme": null,
         "upper_specification": 9.0,
         "lower_specification": -9.0,
-        "cp_point": 0.5841185007045292,
-        "cpk_point": 0.4393857197895713,
+        "cp_point": 0.584,
+        "cpk_point": 0.439,
         "cp_interval": [
-            0.12071407140188907, 1.01856295368876
+            0.121, 1.019
         ],
         "cpk_interval": [
-            0.060269281928522586, 0.8988522372511232
-        ]
+            0.06, 0.899
+        ],
+        "error": null
     },
     "file904": {
         "data": [
@@ -15183,14 +16279,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.503370407031996,
-        "cpk_point": 0.45597929539965026,
+        "cp_point": 0.607,
+        "cpk_point": 0.456,
         "cp_interval": [
-            0.35157631201320105, 0.6724694945525992
+            0.424, 0.811
         ],
         "cpk_interval": [
-            0.30632053502365275, 0.6453557232737661
-        ]
+            0.306, 0.645
+        ],
+        "error": null
     },
     "file905": {
         "data": [
@@ -15200,14 +16297,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.7035007355136493,
-        "cpk_point": 0.6845929223553271,
+        "cp_point": 0.848,
+        "cpk_point": 0.685,
         "cp_interval": [
-            0.5220106542217975, 0.8913650462860119
+            0.629, 1.074
         ],
         "cpk_interval": [
-            0.48151374433798944, 0.8256242273034696
-        ]
+            0.482, 0.921
+        ],
+        "error": null
     },
     "file906": {
         "data": [
@@ -15217,14 +16315,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.180041462532004,
-        "cpk_point": 0.13327387212736946,
+        "cp_point": 0.203,
+        "cpk_point": 0.133,
         "cp_interval": [
-            2.518231160158835e-05, 1.0439982129987202
+            0.0, 1.174
         ],
         "cpk_interval": [
-            1.762383117796713e-05, 0.9227421100986133
-        ]
+            0.0, 1.13
+        ],
+        "error": null
     },
     "file907": {
         "data": [
@@ -15234,14 +16333,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.024371752042280186,
-        "cpk_point": 0.020634734575782025,
+        "cp_point": 0.027,
+        "cpk_point": 0.021,
         "cp_interval": [
-            3.198485840966566e-08, 0.07200424694547848
+            0.0, 0.08
         ],
         "cpk_interval": [
-            2.7330664854465976e-08, 0.06243230066006397
-        ]
+            0.0, 0.062
+        ],
+        "error": null
     },
     "file908": {
         "data": [
@@ -15251,14 +16351,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.5882597447861747,
-        "cpk_point": 0.44116699124857295,
+        "cp_point": 0.619,
+        "cpk_point": 0.441,
         "cp_interval": [
-            0.49698254591553154, 0.6800090372209656
+            0.523, 0.716
         ],
         "cpk_interval": [
-            0.3456016945647543, 0.5534042154680788
-        ]
+            0.346, 0.553
+        ],
+        "error": null
     },
     "file909": {
         "data": [
@@ -15268,14 +16369,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.5202242133657106,
-        "cpk_point": 0.3757329877184953,
+        "cp_point": 0.586,
+        "cpk_point": 0.376,
         "cp_interval": [
-            0.43302023736438633, 0.6057275183463064
+            0.488, 0.683
         ],
         "cpk_interval": [
-            0.2624796913445071, 0.48418514876908625
-        ]
+            0.262, 0.484
+        ],
+        "error": null
     },
     "file910": {
         "data": [
@@ -15285,14 +16387,15 @@
         "lower_extreme": null,
         "upper_specification": -21.0,
         "lower_specification": -39.0,
-        "cp_point": 0.6272800631858849,
-        "cpk_point": 0.16681322424772688,
+        "cp_point": 0.627,
+        "cpk_point": 0.167,
         "cp_interval": [
-            0.5430527370379403, 0.7045305925080267
+            0.543, 0.705
         ],
         "cpk_interval": [
-            0.11378407952771606, 0.23898409752970626
-        ]
+            0.114, 0.239
+        ],
+        "error": null
     },
     "file911": {
         "data": [
@@ -15302,14 +16405,15 @@
         "lower_extreme": null,
         "upper_specification": -21.0,
         "lower_specification": -39.0,
-        "cp_point": 0.2484246101746664,
-        "cpk_point": 0.18658567494806963,
+        "cp_point": 0.248,
+        "cpk_point": 0.187,
         "cp_interval": [
-            0.11061113992932493, 0.43639062726297667
+            0.111, 0.436
         ],
         "cpk_interval": [
-            0.07720587934515448, 0.39543602675007833
-        ]
+            0.077, 0.395
+        ],
+        "error": null
     },
     "file912": {
         "data": [
@@ -15319,14 +16423,15 @@
         "lower_extreme": null,
         "upper_specification": 9.0,
         "lower_specification": -9.0,
-        "cp_point": 0.56923641933111,
-        "cpk_point": 0.3041577303376674,
+        "cp_point": 0.569,
+        "cpk_point": 0.304,
         "cp_interval": [
-            0.4928887586768915, 0.6410722185920007
+            0.493, 0.641
         ],
         "cpk_interval": [
-            0.24107617519612684, 0.38641771302744127
-        ]
+            0.241, 0.386
+        ],
+        "error": null
     },
     "file913": {
         "data": [
@@ -15336,14 +16441,15 @@
         "lower_extreme": null,
         "upper_specification": 9.0,
         "lower_specification": -9.0,
-        "cp_point": 0.5240018356751972,
-        "cpk_point": 0.4015528308777397,
+        "cp_point": 0.524,
+        "cpk_point": 0.402,
         "cp_interval": [
-            0.4378654945236162, 0.6014971482458005
+            0.438, 0.601
         ],
         "cpk_interval": [
-            0.3092871774384555, 0.46725747777973714
-        ]
+            0.309, 0.467
+        ],
+        "error": null
     },
     "file914": {
         "data": [
@@ -15353,14 +16459,15 @@
         "lower_extreme": null,
         "upper_specification": 10.0,
         "lower_specification": 2.0,
-        "cp_point": 1.5389372693966918,
-        "cpk_point": 0.9729751854838404,
+        "cp_point": 1.539,
+        "cpk_point": 0.973,
         "cp_interval": [
-            1.3231170478370073, 1.726699412707305
+            1.323, 1.727
         ],
         "cpk_interval": [
-            0.8120616382791862, 1.0929920629184757
-        ]
+            0.812, 1.093
+        ],
+        "error": null
     },
     "file915": {
         "data": [
@@ -15370,14 +16477,15 @@
         "lower_extreme": null,
         "upper_specification": 10.0,
         "lower_specification": 2.0,
-        "cp_point": 2.5288957845390683,
-        "cpk_point": 2.375130838331345,
+        "cp_point": 2.529,
+        "cpk_point": 2.375,
         "cp_interval": [
-            2.120227346807841, 2.8880614491461802
+            2.12, 2.888
         ],
         "cpk_interval": [
-            1.8304395459218923, 2.800885970613671
-        ]
+            1.83, 2.801
+        ],
+        "error": null
     },
     "file916": {
         "data": [
@@ -15387,14 +16495,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.1001147660002262,
-        "cpk_point": 0.7800870891470641,
+        "cp_point": 1.1,
+        "cpk_point": 0.78,
         "cp_interval": [
-            0.0072618752126728985, 2.088137842348776
+            0.007, 2.088
         ],
         "cpk_interval": [
-            0.005448332903702133, 1.2223528075695511
-        ]
+            0.005, 1.222
+        ],
+        "error": null
     },
     "file917": {
         "data": [
@@ -15404,14 +16513,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.0500074547304588,
-        "cpk_point": 0.6174758143919807,
+        "cp_point": 1.05,
+        "cpk_point": 0.617,
         "cp_interval": [
-            0.4243830043511555, 1.793555940972509
+            0.424, 1.794
         ],
         "cpk_interval": [
-            0.27187116112923476, 0.7068664456666536
-        ]
+            0.272, 0.707
+        ],
+        "error": null
     },
     "file918": {
         "data": [
@@ -15421,14 +16531,15 @@
         "lower_extreme": null,
         "upper_specification": 14.0,
         "lower_specification": 6.0,
-        "cp_point": 0.9745924042182612,
-        "cpk_point": 0.846604074889764,
+        "cp_point": 0.975,
+        "cpk_point": 0.847,
         "cp_interval": [
-            0.014420486144871895, 2.404971013944917
+            0.014, 2.405
         ],
         "cpk_interval": [
-            0.01026681411063981, 1.6453829972953842
-        ]
+            0.01, 1.645
+        ],
+        "error": null
     },
     "file919": {
         "data": [
@@ -15438,14 +16549,15 @@
         "lower_extreme": null,
         "upper_specification": 14.0,
         "lower_specification": 6.0,
-        "cp_point": 0.4715658770676059,
-        "cpk_point": 0.4420283944548961,
+        "cp_point": 0.472,
+        "cpk_point": 0.442,
         "cp_interval": [
-            0.018040005114875652, 0.8546933271793227
+            0.018, 0.855
         ],
         "cpk_interval": [
-            0.014238405706140307, 0.7234823572476171
-        ]
+            0.014, 0.723
+        ],
+        "error": null
     },
     "file920": {
         "data": [
@@ -15455,14 +16567,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 11.0,
         "lower_specification": null,
-        "cp_point": 0.4855504197057782,
-        "cpk_point": 0.3051596665186131,
+        "cp_point": 0.521,
+        "cpk_point": 0.305,
         "cp_interval": [
-            0.411756245955089, 0.5598074617371105
+            0.442, 0.601
         ],
         "cpk_interval": [
-            0.23727653210993696, 0.39202100867780004
-        ]
+            0.237, 0.392
+        ],
+        "error": null
     },
     "file921": {
         "data": [
@@ -15472,14 +16585,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 11.0,
         "lower_specification": null,
-        "cp_point": 0.4805267124077296,
-        "cpk_point": 0.2856679985515462,
+        "cp_point": 0.529,
+        "cpk_point": 0.286,
         "cp_interval": [
-            0.4069632488212523, 0.552933330998161
+            0.448, 0.608
         ],
         "cpk_interval": [
-            0.19004604145021461, 0.3761523576879959
-        ]
+            0.19, 0.376
+        ],
+        "error": null
     },
     "file922": {
         "data": [
@@ -15489,14 +16603,15 @@
         "lower_extreme": null,
         "upper_specification": 44.025,
         "lower_specification": 44.009,
-        "cp_point": 1.8695185286683722,
-        "cpk_point": 1.7755964243529376,
+        "cp_point": 1.87,
+        "cpk_point": 1.776,
         "cp_interval": [
-            1.2611082059871173, 2.1434674700934626
+            1.261, 2.143
         ],
         "cpk_interval": [
-            1.1761732933202926, 2.0337482834324416
-        ]
+            1.176, 2.034
+        ],
+        "error": null
     },
     "file923": {
         "data": [
@@ -15506,14 +16621,15 @@
         "lower_extreme": null,
         "upper_specification": 44.025,
         "lower_specification": 44.009,
-        "cp_point": 1.5135649096618733,
-        "cpk_point": 1.4571783909328753,
+        "cp_point": 1.514,
+        "cpk_point": 1.457,
         "cp_interval": [
-            0.8575681940394884, 1.854095086070121
+            0.858, 1.854
         ],
         "cpk_interval": [
-            0.702667007641268, 1.7851555932989855
-        ]
+            0.703, 1.785
+        ],
+        "error": null
     },
     "file924": {
         "data": [
@@ -15523,14 +16639,15 @@
         "lower_extreme": null,
         "upper_specification": 28.02,
         "lower_specification": 28.009,
-        "cp_point": 1.1451958443859522,
-        "cpk_point": 1.0435220208360987,
+        "cp_point": 1.145,
+        "cpk_point": 1.044,
         "cp_interval": [
-            0.8440054615189034, 1.4094932546891867
+            0.844, 1.409
         ],
         "cpk_interval": [
-            0.7306455946178674, 1.2813610384463108
-        ]
+            0.731, 1.281
+        ],
+        "error": null
     },
     "file925": {
         "data": [
@@ -15540,14 +16657,15 @@
         "lower_extreme": null,
         "upper_specification": 28.02,
         "lower_specification": 28.009,
-        "cp_point": 1.160189048101656,
-        "cpk_point": 1.1132185265875731,
+        "cp_point": 1.16,
+        "cpk_point": 1.113,
         "cp_interval": [
-            0.6839737313872477, 1.3793492882304217
+            0.684, 1.379
         ],
         "cpk_interval": [
-            0.5578846158105725, 1.265958236164356
-        ]
+            0.558, 1.266
+        ],
+        "error": null
     },
     "file926": {
         "data": [
@@ -15557,14 +16675,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.005,
         "lower_specification": null,
-        "cp_point": 0.8708403870524394,
-        "cpk_point": 0.8577203630789216,
+        "cp_point": 0.883,
+        "cpk_point": 0.858,
         "cp_interval": [
-            0.5449930843737426, 1.2231773693825976
+            0.553, 1.241
         ],
         "cpk_interval": [
-            0.49845143956083704, 0.9601022839404265
-        ]
+            0.498, 1.295
+        ],
+        "error": null
     },
     "file927": {
         "data": [
@@ -15574,14 +16693,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.005,
         "lower_specification": null,
-        "cp_point": 0.6442940824127733,
-        "cpk_point": 0.5978769444598008,
+        "cp_point": 0.652,
+        "cpk_point": 0.598,
         "cp_interval": [
-            0.3779819842009972, 0.9477309581480884
+            0.382, 0.958
         ],
         "cpk_interval": [
-            0.3295608756667322, 0.9358655420495989
-        ]
+            0.33, 0.949
+        ],
+        "error": null
     },
     "file928": {
         "data": [
@@ -15591,14 +16711,15 @@
         "lower_extreme": null,
         "upper_specification": 28.16,
         "lower_specification": 27.96,
-        "cp_point": 2.643852862105061,
-        "cpk_point": 1.7009606359118439,
+        "cp_point": 2.644,
+        "cpk_point": 1.701,
         "cp_interval": [
-            1.8321397910039827, 3.0375805570896897
+            1.832, 3.038
         ],
         "cpk_interval": [
-            1.2133562914383687, 2.1747848202162774
-        ]
+            1.213, 2.175
+        ],
+        "error": null
     },
     "file929": {
         "data": [
@@ -15608,14 +16729,15 @@
         "lower_extreme": null,
         "upper_specification": 44.025,
         "lower_specification": 44.009,
-        "cp_point": 3.108670268653041,
-        "cpk_point": 2.3641747090346117,
+        "cp_point": 3.109,
+        "cpk_point": 2.364,
         "cp_interval": [
-            2.3351104321965908, 3.7704672497924334
+            2.335, 3.77
         ],
         "cpk_interval": [
-            1.6978045814516323, 2.9529967280784066
-        ]
+            1.698, 2.953
+        ],
+        "error": null
     },
     "file930": {
         "data": [
@@ -15625,14 +16747,15 @@
         "lower_extreme": null,
         "upper_specification": 44.025,
         "lower_specification": 44.009,
-        "cp_point": 2.5038470626238816,
-        "cpk_point": 2.1945056783201107,
+        "cp_point": 2.504,
+        "cpk_point": 2.195,
         "cp_interval": [
-            1.746739646836685, 2.990032329760586
+            1.747, 2.99
         ],
         "cpk_interval": [
-            1.3667974236716862, 2.806697332266965
-        ]
+            1.367, 2.807
+        ],
+        "error": null
     },
     "file931": {
         "data": [
@@ -15642,14 +16765,15 @@
         "lower_extreme": null,
         "upper_specification": 28.02,
         "lower_specification": 28.009,
-        "cp_point": 1.4485129772230798,
-        "cpk_point": 1.1693430073621212,
+        "cp_point": 1.449,
+        "cpk_point": 1.169,
         "cp_interval": [
-            1.0791689194212848, 1.617105067435111
+            1.079, 1.617
         ],
         "cpk_interval": [
-            0.7586702565002238, 1.314141876250915
-        ]
+            0.759, 1.314
+        ],
+        "error": null
     },
     "file932": {
         "data": [
@@ -15659,14 +16783,15 @@
         "lower_extreme": null,
         "upper_specification": 28.02,
         "lower_specification": 28.009,
-        "cp_point": 0.6658445215335891,
-        "cpk_point": 0.5465919333492087,
+        "cp_point": 0.666,
+        "cpk_point": 0.547,
         "cp_interval": [
-            0.4467163870363002, 0.8514473567789441
+            0.447, 0.851
         ],
         "cpk_interval": [
-            0.3328226666993168, 0.7314540581869445
-        ]
+            0.333, 0.731
+        ],
+        "error": null
     },
     "file933": {
         "data": [
@@ -15676,14 +16801,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.005,
         "lower_specification": null,
-        "cp_point": 0.9541507500553701,
-        "cpk_point": 0.9437104928966981,
+        "cp_point": 0.974,
+        "cpk_point": 0.957,
         "cp_interval": [
-            0.6677134437413492, 1.248955293501414
+            0.681, 1.274
         ],
         "cpk_interval": [
-            0.6188329199015101, 0.9871221790182695
-        ]
+            0.619, 1.348
+        ],
+        "error": null
     },
     "file934": {
         "data": [
@@ -15693,14 +16819,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.005,
         "lower_specification": null,
-        "cp_point": 1.4210135724217536,
-        "cpk_point": 0.9647991710532335,
+        "cp_point": 1.432,
+        "cpk_point": 1.563,
         "cp_interval": [
-            0.9932306243022717, 1.803933084195019
+            1.001, 1.818
         ],
         "cpk_interval": [
-            0.909100012170595, 0.9961303063980108
-        ]
+            1.001, 2.149
+        ],
+        "error": null
     },
     "file935": {
         "data": [
@@ -15710,14 +16837,15 @@
         "lower_extreme": null,
         "upper_specification": 28.16,
         "lower_specification": 27.96,
-        "cp_point": 1.1432968689830598,
-        "cpk_point": 1.123999010918984,
+        "cp_point": 1.143,
+        "cpk_point": 1.124,
         "cp_interval": [
-            0.7890432569081702, 1.4595115604865232
+            0.789, 1.46
         ],
         "cpk_interval": [
-            0.7254188483622259, 1.3792420704675774
-        ]
+            0.725, 1.379
+        ],
+        "error": null
     },
     "file936": {
         "data": [
@@ -15727,14 +16855,15 @@
         "lower_extreme": null,
         "upper_specification": 44.025,
         "lower_specification": 44.009,
-        "cp_point": 1.8687333118943368,
-        "cpk_point": 1.8439656414305106,
+        "cp_point": 1.869,
+        "cpk_point": 1.844,
         "cp_interval": [
-            1.431723245449996, 2.2565852710820966
+            1.432, 2.257
         ],
         "cpk_interval": [
-            1.3643419995688286, 2.2191797238141016
-        ]
+            1.364, 2.219
+        ],
+        "error": null
     },
     "file937": {
         "data": [
@@ -15744,14 +16873,15 @@
         "lower_extreme": null,
         "upper_specification": 44.025,
         "lower_specification": 44.009,
-        "cp_point": 1.7015200193101172,
-        "cpk_point": 1.2773918754211004,
+        "cp_point": 1.702,
+        "cpk_point": 1.277,
         "cp_interval": [
-            1.2860331348943745, 1.9148830088082025
+            1.286, 1.915
         ],
         "cpk_interval": [
-            0.8900265026525542, 1.4764825878548018
-        ]
+            0.89, 1.476
+        ],
+        "error": null
     },
     "file938": {
         "data": [
@@ -15761,14 +16891,15 @@
         "lower_extreme": null,
         "upper_specification": 28.02,
         "lower_specification": 28.009,
-        "cp_point": 0.9933092276615272,
-        "cpk_point": 0.8688391055104311,
+        "cp_point": 0.993,
+        "cpk_point": 0.869,
         "cp_interval": [
-            0.7682237027322459, 1.128838015849609
+            0.768, 1.129
         ],
         "cpk_interval": [
-            0.6657410303783313, 1.0648109888846642
-        ]
+            0.666, 1.065
+        ],
+        "error": null
     },
     "file939": {
         "data": [
@@ -15778,14 +16909,15 @@
         "lower_extreme": null,
         "upper_specification": 28.02,
         "lower_specification": 28.009,
-        "cp_point": 1.037253534597626,
-        "cpk_point": 0.9122463529260882,
+        "cp_point": 1.037,
+        "cpk_point": 0.912,
         "cp_interval": [
-            0.8472180290815678, 1.2041159007353683
+            0.847, 1.204
         ],
         "cpk_interval": [
-            0.688449723816067, 1.1312252666881097
-        ]
+            0.688, 1.131
+        ],
+        "error": null
     },
     "file940": {
         "data": [
@@ -15795,14 +16927,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.005,
         "lower_specification": null,
-        "cp_point": 0.6908755882211277,
-        "cpk_point": 0.6354514180843495,
+        "cp_point": 0.701,
+        "cpk_point": 0.635,
         "cp_interval": [
-            0.45958621012802986, 0.9402678661091073
+            0.466, 0.954
         ],
         "cpk_interval": [
-            0.3948502383488825, 0.9365528870305967
-        ]
+            0.395, 0.937
+        ],
+        "error": null
     },
     "file941": {
         "data": [
@@ -15812,14 +16945,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 0.005,
         "lower_specification": null,
-        "cp_point": 1.312985680753585,
-        "cpk_point": 0.9544694143700847,
+        "cp_point": 1.321,
+        "cpk_point": 1.375,
         "cp_interval": [
-            0.8462764599173156, 1.8309693769834554
+            0.852, 1.842
         ],
         "cpk_interval": [
-            0.8355219052572541, 0.9791049088277621
-        ]
+            0.836, 2.013
+        ],
+        "error": null
     },
     "file942": {
         "data": [
@@ -15829,14 +16963,15 @@
         "lower_extreme": null,
         "upper_specification": 28.16,
         "lower_specification": 27.96,
-        "cp_point": 1.2234152578036999,
-        "cpk_point": 1.1764514694232606,
+        "cp_point": 1.223,
+        "cpk_point": 1.176,
         "cp_interval": [
-            0.7988609110493577, 1.6226200329085463
+            0.799, 1.623
         ],
         "cpk_interval": [
-            0.7410313657800214, 1.5871774482014518
-        ]
+            0.741, 1.587
+        ],
+        "error": null
     },
     "file943": {
         "data": [
@@ -15846,14 +16981,15 @@
         "lower_extreme": null,
         "upper_specification": 88.66,
         "lower_specification": 88.38,
-        "cp_point": 3.7921911950894085,
-        "cpk_point": 2.669558899661234,
+        "cp_point": 3.792,
+        "cpk_point": 2.67,
         "cp_interval": [
-            2.2967796251239587, 5.057149480167625
+            2.297, 5.057
         ],
         "cpk_interval": [
-            1.5441749885273262, 3.7291026427897713
-        ]
+            1.544, 3.729
+        ],
+        "error": null
     },
     "file944": {
         "data": [
@@ -15863,14 +16999,15 @@
         "lower_extreme": null,
         "upper_specification": 99.7,
         "lower_specification": 99.55,
-        "cp_point": 1.5960487018078529,
-        "cpk_point": 0.7745649513594572,
+        "cp_point": 1.596,
+        "cpk_point": 0.775,
         "cp_interval": [
-            0.9008023201809153, 1.9432703999113043
+            0.901, 1.943
         ],
         "cpk_interval": [
-            0.24143852395202134, 1.0102232603087886
-        ]
+            0.241, 1.01
+        ],
+        "error": null
     },
     "file945": {
         "data": [
@@ -15880,14 +17017,15 @@
         "lower_extreme": null,
         "upper_specification": 98.338,
         "lower_specification": 98.271,
-        "cp_point": 0.9708336627463364,
-        "cpk_point": 0.6683423412705787,
+        "cp_point": 0.971,
+        "cpk_point": 0.668,
         "cp_interval": [
-            0.5760141439902716, 1.3202739641482575
+            0.576, 1.32
         ],
         "cpk_interval": [
-            0.367242135170269, 0.9815685114713172
-        ]
+            0.367, 0.982
+        ],
+        "error": null
     },
     "file946": {
         "data": [
@@ -15897,14 +17035,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.620837238060037,
-        "cpk_point": 2.337248542104532,
+        "cp_point": 2.621,
+        "cpk_point": 2.337,
         "cp_interval": [
-            1.60078990830815, 3.4707547375590533
+            1.601, 3.471
         ],
         "cpk_interval": [
-            1.3906927359950652, 3.229775605287866
-        ]
+            1.391, 3.23
+        ],
+        "error": null
     },
     "file947": {
         "data": [
@@ -15914,14 +17053,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": -7.0,
-        "cp_point": 2.184724636134705,
-        "cpk_point": 1.9562166497713558,
+        "cp_point": 2.185,
+        "cpk_point": 1.956,
         "cp_interval": [
-            1.2528074161315625, 3.006964643976355
+            1.253, 3.007
         ],
         "cpk_interval": [
-            1.046077038909775, 2.8364333399475545
-        ]
+            1.046, 2.836
+        ],
+        "error": null
     },
     "file948": {
         "data": [
@@ -15931,14 +17071,15 @@
         "lower_extreme": null,
         "upper_specification": 10.0,
         "lower_specification": 2.0,
-        "cp_point": 1.3834421102589127,
-        "cpk_point": 1.3295936770749333,
+        "cp_point": 1.383,
+        "cpk_point": 1.33,
         "cp_interval": [
-            0.7914362020193716, 1.909740395374486
+            0.791, 1.91
         ],
         "cpk_interval": [
-            0.725708499084327, 1.6997377071595365
-        ]
+            0.726, 1.7
+        ],
+        "error": null
     },
     "file949": {
         "data": [
@@ -15948,14 +17089,15 @@
         "lower_extreme": null,
         "upper_specification": 10.0,
         "lower_specification": 2.0,
-        "cp_point": 2.4091159560679727,
-        "cpk_point": 2.2103438284470642,
+        "cp_point": 2.409,
+        "cpk_point": 2.21,
         "cp_interval": [
-            1.4428334235413716, 3.2053383479494615
+            1.443, 3.205
         ],
         "cpk_interval": [
-            1.1940020081098448, 3.0124331692540167
-        ]
+            1.194, 3.012
+        ],
+        "error": null
     },
     "file950": {
         "data": [
@@ -15965,14 +17107,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.0393167552100526,
-        "cpk_point": 0.396623650779252,
+        "cp_point": 1.039,
+        "cpk_point": 0.397,
         "cp_interval": [
-            0.6273139304547984, 1.3801457558287258
+            0.627, 1.38
         ],
         "cpk_interval": [
-            0.17712015407303797, 0.6047271691136331
-        ]
+            0.177, 0.605
+        ],
+        "error": null
     },
     "file951": {
         "data": [
@@ -15982,14 +17125,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.3363412251489222,
-        "cpk_point": 0.430066848281982,
+        "cp_point": 1.336,
+        "cpk_point": 0.43,
         "cp_interval": [
-            0.7808255638092648, 1.8344475903052626
+            0.781, 1.834
         ],
         "cpk_interval": [
-            0.1985748127737413, 0.6772636740173356
-        ]
+            0.199, 0.677
+        ],
+        "error": null
     },
     "file952": {
         "data": [
@@ -15999,14 +17143,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": 1.0,
-        "cp_point": 0.7627432820570861,
-        "cpk_point": 0.5645318366017504,
+        "cp_point": 0.763,
+        "cpk_point": 0.565,
         "cp_interval": [
-            0.3876804084901337, 1.061132878737222
+            0.388, 1.061
         ],
         "cpk_interval": [
-            0.2044053650833849, 0.848190491775259
-        ]
+            0.204, 0.848
+        ],
+        "error": null
     },
     "file953": {
         "data": [
@@ -16016,14 +17161,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 2.281879872405196,
-        "cpk_point": 1.6548661521919588,
+        "cp_point": 2.282,
+        "cpk_point": 1.655,
         "cp_interval": [
-            1.5257258076385791, 2.7583939942665485
+            1.526, 2.758
         ],
         "cpk_interval": [
-            0.948633906186821, 2.384039517176114
-        ]
+            0.949, 2.384
+        ],
+        "error": null
     },
     "file954": {
         "data": [
@@ -16033,14 +17179,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": 1.0,
-        "cp_point": 1.503328234204082,
-        "cpk_point": 0.5390790458382211,
+        "cp_point": 1.503,
+        "cpk_point": 0.539,
         "cp_interval": [
-            0.8853268331973132, 2.0530512805809846
+            0.885, 2.053
         ],
         "cpk_interval": [
-            0.27471427026943623, 0.8189151412863863
-        ]
+            0.275, 0.819
+        ],
+        "error": null
     },
     "file955": {
         "data": [
@@ -16050,14 +17197,15 @@
         "lower_extreme": null,
         "upper_specification": 8.0,
         "lower_specification": -8.0,
-        "cp_point": 1.9238551981221155,
-        "cpk_point": 1.756920660648765,
+        "cp_point": 1.924,
+        "cpk_point": 1.757,
         "cp_interval": [
-            1.109759429318912, 2.3665903975282228
+            1.11, 2.367
         ],
         "cpk_interval": [
-            0.8594187921669032, 2.201781877197394
-        ]
+            0.859, 2.202
+        ],
+        "error": null
     },
     "file956": {
         "data": [
@@ -16067,14 +17215,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.34058583409812315,
-        "cpk_point": 0.08785593018455845,
+        "cp_point": 0.817,
+        "cpk_point": 0.088,
         "cp_interval": [
-            0.21608981030495986, 0.4514095078668198
+            0.519, 1.083
         ],
         "cpk_interval": [
-            -0.05086683564058563, 0.24751642334223625
-        ]
+            -0.051, 0.248
+        ],
+        "error": null
     },
     "file957": {
         "data": [
@@ -16084,14 +17233,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.2697245335667869,
-        "cpk_point": -0.0772945533456964,
+        "cp_point": 0.809,
+        "cpk_point": -0.077,
         "cp_interval": [
-            0.1661091839229333, 0.36029513374327543
+            0.498, 1.081
         ],
         "cpk_interval": [
-            -0.22401097595653852, 0.08542410637032369
-        ]
+            -0.224, 0.085
+        ],
+        "error": null
     },
     "file958": {
         "data": [
@@ -16101,14 +17251,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.820978427513327,
-        "cpk_point": 0.799407245293755,
+        "cp_point": 2.101,
+        "cpk_point": 3.054,
         "cp_interval": [
-            1.292093316190643, 2.193898311778184
+            1.491, 2.531
         ],
         "cpk_interval": [
-            0.44087140315718565, 0.9773294106729099
-        ]
+            1.45, 4.357
+        ],
+        "error": null
     },
     "file959": {
         "data": [
@@ -16118,14 +17269,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.6523441637744953,
-        "cpk_point": 0.7948298641059185,
+        "cp_point": 1.743,
+        "cpk_point": 1.868,
         "cp_interval": [
-            0.7169091867641363, 2.5306275951568487
+            0.756, 2.67
         ],
         "cpk_interval": [
-            0.571817483572879, 0.9273013680094208
-        ]
+            0.723, 3.108
+        ],
+        "error": null
     },
     "file960": {
         "data": [
@@ -16135,14 +17287,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.8544953915435671,
-        "cpk_point": 0.7165853832570985,
+        "cp_point": 2.119,
+        "cpk_point": 2.627,
         "cp_interval": [
-            1.0988133564786096, 2.209459570885069
+            1.256, 2.525
         ],
         "cpk_interval": [
-            0.48065402807121366, 0.943934252216898
-        ]
+            1.17, 4.44
+        ],
+        "error": null
     },
     "file961": {
         "data": [
@@ -16152,14 +17305,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.1871832059406036,
-        "cpk_point": 0.7892731459488428,
+        "cp_point": 1.241,
+        "cpk_point": 1.231,
         "cp_interval": [
-            0.19337414925024543, 2.4614098883544746
+            0.202, 2.574
         ],
         "cpk_interval": [
-            0.1852528666127869, 0.9174578448789074
-        ]
+            0.185, 2.783
+        ],
+        "error": null
     },
     "file962": {
         "data": [
@@ -16169,14 +17323,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.0275562200381811,
-        "cpk_point": 0.8530021115659798,
+        "cp_point": 1.082,
+        "cpk_point": 1.078,
         "cp_interval": [
-            0.5107101374300913, 1.4947571417114314
+            0.538, 1.573
         ],
         "cpk_interval": [
-            0.4781752319824028, 0.9639525311600223
-        ]
+            0.478, 1.714
+        ],
+        "error": null
     },
     "file963": {
         "data": [
@@ -16186,14 +17341,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 0.9144364705925104,
-        "cpk_point": 0.6998329892274805,
+        "cp_point": 1.05,
+        "cpk_point": 0.952,
         "cp_interval": [
-            0.21133554490029116, 1.6632208499655532
+            0.243, 1.909
         ],
         "cpk_interval": [
-            0.1979018584911598, 0.8456032694134064
-        ]
+            0.198, 1.931
+        ],
+        "error": null
     },
     "file964": {
         "data": [
@@ -16203,14 +17359,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.6206710533021998,
-        "cpk_point": 0.6080837682729476,
+        "cp_point": 0.705,
+        "cpk_point": 0.608,
         "cp_interval": [
-            0.09068920246187759, 1.2951337124553812
+            0.103, 1.472
         ],
         "cpk_interval": [
-            0.08212438780829037, 0.8516161261807312
-        ]
+            0.082, 1.419
+        ],
+        "error": null
     },
     "file965": {
         "data": [
@@ -16220,14 +17377,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": -6.0,
-        "cp_point": 1.624174484591435,
-        "cpk_point": 1.2714966151898626,
+        "cp_point": 1.624,
+        "cpk_point": 1.271,
         "cp_interval": [
-            1.230893543086815, 1.9824424367747915
+            1.231, 1.982
         ],
         "cpk_interval": [
-            0.9949790264107261, 1.5016228572565995
-        ]
+            0.995, 1.502
+        ],
+        "error": null
     },
     "file966": {
         "data": [
@@ -16237,14 +17395,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": -6.0,
-        "cp_point": 1.7649616339886667,
-        "cpk_point": 1.1475649075621626,
+        "cp_point": 1.765,
+        "cpk_point": 1.148,
         "cp_interval": [
-            1.331664272472545, 2.032155115903395
+            1.332, 2.032
         ],
         "cpk_interval": [
-            0.7798669163865817, 1.426835724637482
-        ]
+            0.78, 1.427
+        ],
+        "error": null
     },
     "file967": {
         "data": [
@@ -16254,14 +17413,15 @@
         "lower_extreme": null,
         "upper_specification": -11.0,
         "lower_specification": -29.0,
-        "cp_point": 2.1796657182017505,
-        "cpk_point": 1.7563088710497503,
+        "cp_point": 2.18,
+        "cpk_point": 1.756,
         "cp_interval": [
-            1.7041232673397142, 2.5436579279334053
+            1.704, 2.544
         ],
         "cpk_interval": [
-            1.3607486212971789, 2.168145609386683
-        ]
+            1.361, 2.168
+        ],
+        "error": null
     },
     "file968": {
         "data": [
@@ -16271,14 +17431,15 @@
         "lower_extreme": null,
         "upper_specification": -1.0,
         "lower_specification": -19.0,
-        "cp_point": 1.1853537350467682,
-        "cpk_point": 0.845078963995384,
+        "cp_point": 1.185,
+        "cpk_point": 0.845,
         "cp_interval": [
-            0.8441845144588852, 1.4810615976655501
+            0.844, 1.481
         ],
         "cpk_interval": [
-            0.5560265106813431, 1.0666196546721824
-        ]
+            0.556, 1.067
+        ],
+        "error": null
     },
     "file969": {
         "data": [
@@ -16288,14 +17449,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 1.2583960309954472,
-        "cpk_point": 0.7119845846272783,
+        "cp_point": 1.528,
+        "cpk_point": 1.529,
         "cp_interval": [
-            0.9402026506747998, 1.5514409788562724
+            1.141, 1.883
         ],
         "cpk_interval": [
-            0.573059809979598, 0.8136018972717863
-        ]
+            1.069, 2.001
+        ],
+        "error": null
     },
     "file970": {
         "data": [
@@ -16305,14 +17467,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.8292347664262834,
-        "cpk_point": 0.7778523043568353,
+        "cp_point": 1.082,
+        "cpk_point": 0.778,
         "cp_interval": [
-            0.6534225182440491, 1.0038212943020008
+            0.852, 1.309
         ],
         "cpk_interval": [
-            0.5765218140578381, 0.9517039209244363
-        ]
+            0.577, 0.995
+        ],
+        "error": null
     },
     "file971": {
         "data": [
@@ -16322,14 +17485,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.4245843622674499,
-        "cpk_point": 0.7506789094606597,
+        "cp_point": 1.594,
+        "cpk_point": 1.618,
         "cp_interval": [
-            0.9250241660398735, 1.933485510057612
+            1.035, 2.164
         ],
         "cpk_interval": [
-            0.6153918140287209, 0.8459457857396735
-        ]
+            0.977, 2.342
+        ],
+        "error": null
     },
     "file972": {
         "data": [
@@ -16339,14 +17503,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.1482994648250133,
-        "cpk_point": 0.7467364405498695,
+        "cp_point": 1.289,
+        "cpk_point": 1.298,
         "cp_interval": [
-            0.8274260852892196, 1.4616701131521044
+            0.929, 1.641
         ],
         "cpk_interval": [
-            0.6224062828653323, 0.8356333941886266
-        ]
+            0.87, 1.762
+        ],
+        "error": null
     },
     "file973": {
         "data": [
@@ -16356,14 +17521,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.7497477323466403,
-        "cpk_point": 0.6922555964460834,
+        "cp_point": 0.789,
+        "cpk_point": 0.692,
         "cp_interval": [
-            0.5576732789600459, 0.9402300788250294
+            0.587, 0.99
         ],
         "cpk_interval": [
-            0.46747050637020626, 0.9068719303216226
-        ]
+            0.467, 0.955
+        ],
+        "error": null
     },
     "file974": {
         "data": [
@@ -16373,14 +17539,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.7861983623241751,
-        "cpk_point": 0.7733607631391294,
+        "cp_point": 0.887,
+        "cpk_point": 0.791,
         "cp_interval": [
-            0.571961385338181, 0.9966554598221439
+            0.645, 1.124
         ],
         "cpk_interval": [
-            0.5321261506345889, 0.838627404629507
-        ]
+            0.532, 1.092
+        ],
+        "error": null
     },
     "file975": {
         "data": [
@@ -16390,14 +17557,15 @@
         "lower_extreme": null,
         "upper_specification": -11.0,
         "lower_specification": -29.0,
-        "cp_point": 0.6381652216479291,
-        "cpk_point": 0.2891794921070445,
+        "cp_point": 0.638,
+        "cpk_point": 0.289,
         "cp_interval": [
-            0.3897526949040967, 0.8446185127645115
+            0.39, 0.845
         ],
         "cpk_interval": [
-            0.11295104516972665, 0.47493384923355636
-        ]
+            0.113, 0.475
+        ],
+        "error": null
     },
     "file976": {
         "data": [
@@ -16407,14 +17575,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 1.0,
-        "cp_point": 1.446843359076146,
-        "cpk_point": 1.3688583016362157,
+        "cp_point": 1.447,
+        "cpk_point": 1.369,
         "cp_interval": [
-            1.071551966550592, 1.7786948434533667
+            1.072, 1.779
         ],
         "cpk_interval": [
-            0.9657928841439571, 1.7513234333762373
-        ]
+            0.966, 1.751
+        ],
+        "error": null
     },
     "file977": {
         "data": [
@@ -16424,14 +17593,15 @@
         "lower_extreme": null,
         "upper_specification": -11.0,
         "lower_specification": -29.0,
-        "cp_point": 0.6364355440443393,
-        "cpk_point": -0.3919332942424847,
+        "cp_point": 0.636,
+        "cpk_point": -0.392,
         "cp_interval": [
-            0.3740454779639845, 0.8476015027477081
+            0.374, 0.848
         ],
         "cpk_interval": [
-            -0.5878438459702734, -0.188667037524886
-        ]
+            -0.588, -0.189
+        ],
+        "error": null
     },
     "file978": {
         "data": [
@@ -16441,14 +17611,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 1.0,
-        "cp_point": 1.5791587633733284,
-        "cpk_point": 0.9833480154273003,
+        "cp_point": 1.579,
+        "cpk_point": 0.983,
         "cp_interval": [
-            1.2188557342788275, 1.9064100456503315
+            1.219, 1.906
         ],
         "cpk_interval": [
-            0.7368683482506043, 1.1635845040302921
-        ]
+            0.737, 1.164
+        ],
+        "error": null
     },
     "file979": {
         "data": [
@@ -16458,14 +17629,15 @@
         "lower_extreme": null,
         "upper_specification": -1.0,
         "lower_specification": -19.0,
-        "cp_point": 1.1699699678813353,
-        "cpk_point": 1.1088466437644044,
+        "cp_point": 1.17,
+        "cpk_point": 1.109,
         "cp_interval": [
-            0.7325184262883755, 1.4562077811704606
+            0.733, 1.456
         ],
         "cpk_interval": [
-            0.5522454090614076, 1.3202031537968606
-        ]
+            0.552, 1.32
+        ],
+        "error": null
     },
     "file980": {
         "data": [
@@ -16475,14 +17647,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.5466897120992287,
-        "cpk_point": 0.5307356037399865,
+        "cp_point": 1.547,
+        "cpk_point": 0.531,
         "cp_interval": [
-            1.086297767743283, 1.8167215603946416
+            1.086, 1.817
         ],
         "cpk_interval": [
-            0.31460128909589424, 0.6537593520918401
-        ]
+            0.315, 0.654
+        ],
+        "error": null
     },
     "file981": {
         "data": [
@@ -16492,14 +17665,15 @@
         "lower_extreme": null,
         "upper_specification": -1.0,
         "lower_specification": -19.0,
-        "cp_point": 0.6721828626782441,
-        "cpk_point": 0.6301977376314912,
+        "cp_point": 0.672,
+        "cpk_point": 0.63,
         "cp_interval": [
-            0.4056919036037745, 0.892995433908685
+            0.406, 0.893
         ],
         "cpk_interval": [
-            0.28280315326501515, 0.8566557285329403
-        ]
+            0.283, 0.857
+        ],
+        "error": null
     },
     "file982": {
         "data": [
@@ -16509,14 +17683,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.5255658318094083,
-        "cpk_point": 1.1141191747309636,
+        "cp_point": 1.526,
+        "cpk_point": 1.114,
         "cp_interval": [
-            1.0552196971788592, 1.7513892053840623
+            1.055, 1.751
         ],
         "cpk_interval": [
-            0.8796173436951812, 1.3308317871323232
-        ]
+            0.88, 1.331
+        ],
+        "error": null
     },
     "file983": {
         "data": [
@@ -16526,14 +17701,15 @@
         "lower_extreme": null,
         "upper_specification": 11.0,
         "lower_specification": 5.0,
-        "cp_point": 1.2405175166029996,
-        "cpk_point": 0.8504241585964004,
+        "cp_point": 1.241,
+        "cpk_point": 0.85,
         "cp_interval": [
-            0.9484458479767891, 1.5081140863895555
+            0.948, 1.508
         ],
         "cpk_interval": [
-            0.6242529931461845, 1.0997604339052196
-        ]
+            0.624, 1.1
+        ],
+        "error": null
     },
     "file984": {
         "data": [
@@ -16543,14 +17719,15 @@
         "lower_extreme": null,
         "upper_specification": 11.0,
         "lower_specification": 5.0,
-        "cp_point": 0.7515215660968055,
-        "cpk_point": 0.6739937797118394,
+        "cp_point": 0.752,
+        "cpk_point": 0.674,
         "cp_interval": [
-            0.5151370759090852, 0.9556511652495469
+            0.515, 0.956
         ],
         "cpk_interval": [
-            0.42248223428752535, 0.8717548248083061
-        ]
+            0.422, 0.872
+        ],
+        "error": null
     },
     "file985": {
         "data": [
@@ -16560,14 +17737,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.59094663203764,
-        "cpk_point": 0.916000604648707,
+        "cp_point": 1.664,
+        "cpk_point": 1.931,
         "cp_interval": [
-            1.2475929602285816, 1.8836967360290324
+            1.305, 1.97
         ],
         "cpk_interval": [
-            0.8240045763071946, 1.00807294746738
-        ]
+            1.368, 2.512
+        ],
+        "error": null
     },
     "file986": {
         "data": [
@@ -16577,14 +17755,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.3264859739925623,
-        "cpk_point": 0.8590085194010241,
+        "cp_point": 1.387,
+        "cpk_point": 1.474,
         "cp_interval": [
-            0.9439833189974483, 1.7127132014337942
+            0.987, 1.791
         ],
         "cpk_interval": [
-            0.770087406575357, 0.9268699826598262
-        ]
+            0.975, 2.018
+        ],
+        "error": null
     },
     "file987": {
         "data": [
@@ -16594,14 +17773,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 0.7684071966394698,
-        "cpk_point": 0.7193952516958135,
+        "cp_point": 0.845,
+        "cpk_point": 0.719,
         "cp_interval": [
-            0.5401715928108765, 0.9744678125746686
+            0.594, 1.072
         ],
         "cpk_interval": [
-            0.4712023195691208, 0.9400680785139998
-        ]
+            0.471, 0.995
+        ],
+        "error": null
     },
     "file988": {
         "data": [
@@ -16611,14 +17791,15 @@
         "lower_extreme": null,
         "upper_specification": 47.02,
         "lower_specification": 46.77,
-        "cp_point": 1.608298953300463,
-        "cpk_point": 1.5748821304757676,
+        "cp_point": 1.608,
+        "cpk_point": 1.575,
         "cp_interval": [
-            1.2172840920328991, 2.0884426027514373
+            1.217, 2.088
         ],
         "cpk_interval": [
-            1.0481771800271917, 1.9738980526291656
-        ]
+            1.048, 1.974
+        ],
+        "error": null
     },
     "file989": {
         "data": [
@@ -16628,14 +17809,15 @@
         "lower_extreme": null,
         "upper_specification": 61.6,
         "lower_specification": 61.4,
-        "cp_point": 1.8721647856985508,
-        "cpk_point": 1.3636690622714656,
+        "cp_point": 1.872,
+        "cpk_point": 1.364,
         "cp_interval": [
-            1.4080275642631335, 2.282277007001132
+            1.408, 2.282
         ],
         "cpk_interval": [
-            0.9805775557034443, 1.7546435579045714
-        ]
+            0.981, 1.755
+        ],
+        "error": null
     },
     "file990": {
         "data": [
@@ -16645,14 +17827,15 @@
         "lower_extreme": null,
         "upper_specification": 58.248,
         "lower_specification": 58.207,
-        "cp_point": 0.8459259065359954,
-        "cpk_point": 0.5629184367716554,
+        "cp_point": 0.846,
+        "cpk_point": 0.563,
         "cp_interval": [
-            0.5415973310431353, 1.207381725832971
+            0.542, 1.207
         ],
         "cpk_interval": [
-            0.3427760978941876, 0.7983734661827572
-        ]
+            0.343, 0.798
+        ],
+        "error": null
     },
     "file991": {
         "data": [
@@ -16662,14 +17845,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": -6.0,
-        "cp_point": 1.6668740861033642,
-        "cpk_point": 1.4040635118302847,
+        "cp_point": 1.667,
+        "cpk_point": 1.404,
         "cp_interval": [
-            1.3899462176633375, 1.9068296833299816
+            1.39, 1.907
         ],
         "cpk_interval": [
-            1.1410079924165966, 1.6171897983185188
-        ]
+            1.141, 1.617
+        ],
+        "error": null
     },
     "file992": {
         "data": [
@@ -16679,14 +17863,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": -6.0,
-        "cp_point": 1.3978109472086058,
-        "cpk_point": 1.3762564505056996,
+        "cp_point": 1.398,
+        "cpk_point": 1.376,
         "cp_interval": [
-            1.184142961758175, 1.598195632146838
+            1.184, 1.598
         ],
         "cpk_interval": [
-            1.1556896761019992, 1.5637971845164413
-        ]
+            1.156, 1.564
+        ],
+        "error": null
     },
     "file993": {
         "data": [
@@ -16696,14 +17881,15 @@
         "lower_extreme": null,
         "upper_specification": -11.0,
         "lower_specification": -29.0,
-        "cp_point": 0.7359491802841365,
-        "cpk_point": 0.6351547994416414,
+        "cp_point": 0.736,
+        "cpk_point": 0.635,
         "cp_interval": [
-            0.5714222201665562, 0.8946563343241885
+            0.571, 0.895
         ],
         "cpk_interval": [
-            0.46920821284049974, 0.83201405124771
-        ]
+            0.469, 0.832
+        ],
+        "error": null
     },
     "file994": {
         "data": [
@@ -16713,14 +17899,15 @@
         "lower_extreme": null,
         "upper_specification": -1.0,
         "lower_specification": -19.0,
-        "cp_point": 0.933160264873505,
-        "cpk_point": 0.9047884800177578,
+        "cp_point": 0.933,
+        "cpk_point": 0.905,
         "cp_interval": [
-            0.7635501812373835, 1.0829500011515456
+            0.764, 1.083
         ],
         "cpk_interval": [
-            0.7174019944739252, 1.0630172856306117
-        ]
+            0.717, 1.063
+        ],
+        "error": null
     },
     "file995": {
         "data": [
@@ -16730,14 +17917,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.7170343093153941,
-        "cpk_point": 0.7023379881269379,
+        "cp_point": 0.866,
+        "cpk_point": 0.702,
         "cp_interval": [
-            0.5533385695173645, 0.8844601454286015
+            0.668, 1.068
         ],
         "cpk_interval": [
-            0.517249944095296, 0.8082325028957038
-        ]
+            0.517, 0.921
+        ],
+        "error": null
     },
     "file996": {
         "data": [
@@ -16747,14 +17935,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 1.0632430823036643,
-        "cpk_point": 0.8952718986205113,
+        "cp_point": 1.307,
+        "cpk_point": 1.357,
         "cp_interval": [
-            0.9361373179024916, 1.1501935458547243
+            1.15, 1.413
         ],
         "cpk_interval": [
-            0.7653425714402593, 0.9928019539494132
-        ]
+            1.086, 1.544
+        ],
+        "error": null
     },
     "file997": {
         "data": [
@@ -16764,14 +17953,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.4573932369017881,
-        "cpk_point": 0.8975133313829713,
+        "cp_point": 1.631,
+        "cpk_point": 1.874,
         "cp_interval": [
-            1.2981672152021695, 1.6124864060223978
+            1.453, 1.805
         ],
         "cpk_interval": [
-            0.7879991804462689, 0.9642955377537681
-        ]
+            1.564, 2.184
+        ],
+        "error": null
     },
     "file998": {
         "data": [
@@ -16781,14 +17971,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.1661173221775467,
-        "cpk_point": 0.7839950707407616,
+        "cp_point": 1.308,
+        "cpk_point": 1.463,
         "cp_interval": [
-            0.9959543714443903, 1.3337527409492096
+            1.117, 1.496
         ],
         "cpk_interval": [
-            0.7174737889178839, 0.8662643791905701
-        ]
+            1.158, 1.771
+        ],
+        "error": null
     },
     "file999": {
         "data": [
@@ -16798,14 +17989,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.9579007948691644,
-        "cpk_point": 0.7878781076751732,
+        "cp_point": 1.074,
+        "cpk_point": 1.058,
         "cp_interval": [
-            0.8223226414031577, 1.0861320659123126
+            0.922, 1.218
         ],
         "cpk_interval": [
-            0.7262673395078615, 0.8415606959668438
-        ]
+            0.86, 1.268
+        ],
+        "error": null
     },
     "file1000": {
         "data": [
@@ -16815,14 +18007,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.213021537056984,
-        "cpk_point": 0.9975694956289026,
+        "cp_point": 1.277,
+        "cpk_point": 1.347,
         "cp_interval": [
-            1.0626111064981292, 1.362768266565465
+            1.119, 1.434
         ],
         "cpk_interval": [
-            0.8999713839173776, 1.0826534867643183
-        ]
+            1.091, 1.602
+        ],
+        "error": null
     },
     "file1001": {
         "data": [
@@ -16832,14 +18025,15 @@
         "lower_extreme": null,
         "upper_specification": -11.0,
         "lower_specification": -29.0,
-        "cp_point": 0.545752204136404,
-        "cpk_point": 0.1350584970545444,
+        "cp_point": 0.546,
+        "cpk_point": 0.135,
         "cp_interval": [
-            0.4118223670154701, 0.6675541550811993
+            0.412, 0.668
         ],
         "cpk_interval": [
-            0.06377695519534192, 0.22989045618517215
-        ]
+            0.064, 0.23
+        ],
+        "error": null
     },
     "file1002": {
         "data": [
@@ -16849,14 +18043,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 1.0,
-        "cp_point": 2.0948714081487454,
-        "cpk_point": 1.9517259170490406,
+        "cp_point": 2.095,
+        "cpk_point": 1.952,
         "cp_interval": [
-            1.8258900008276087, 2.2999753548536637
+            1.826, 2.3
         ],
         "cpk_interval": [
-            1.6212067249231126, 2.1504171035310806
-        ]
+            1.621, 2.15
+        ],
+        "error": null
     },
     "file1003": {
         "data": [
@@ -16866,14 +18061,15 @@
         "lower_extreme": null,
         "upper_specification": -11.0,
         "lower_specification": -29.0,
-        "cp_point": 0.5030785210497442,
-        "cpk_point": -0.3182581138477482,
+        "cp_point": 0.503,
+        "cpk_point": -0.318,
         "cp_interval": [
-            0.37989537366481896, 0.615722265641365
+            0.38, 0.616
         ],
         "cpk_interval": [
-            -0.45311121581952757, -0.20322973802922537
-        ]
+            -0.453, -0.203
+        ],
+        "error": null
     },
     "file1004": {
         "data": [
@@ -16883,14 +18079,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 1.0,
-        "cp_point": 1.1878243373628046,
-        "cpk_point": 0.8118845222370672,
+        "cp_point": 1.188,
+        "cpk_point": 0.812,
         "cp_interval": [
-            0.9043720252610201, 1.505455787814912
+            0.904, 1.505
         ],
         "cpk_interval": [
-            0.5911870823471902, 1.0761514329923172
-        ]
+            0.591, 1.076
+        ],
+        "error": null
     },
     "file1005": {
         "data": [
@@ -16900,14 +18097,15 @@
         "lower_extreme": null,
         "upper_specification": -1.0,
         "lower_specification": -19.0,
-        "cp_point": 0.5897099143944324,
-        "cpk_point": 0.49216398190864247,
+        "cp_point": 0.59,
+        "cpk_point": 0.492,
         "cp_interval": [
-            0.46435987329169004, 0.7063585348571961
+            0.464, 0.706
         ],
         "cpk_interval": [
-            0.3670592754108701, 0.6385395761550253
-        ]
+            0.367, 0.639
+        ],
+        "error": null
     },
     "file1006": {
         "data": [
@@ -16917,14 +18115,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.6098227728388066,
-        "cpk_point": 0.4461146766043014,
+        "cp_point": 1.61,
+        "cpk_point": 0.446,
         "cp_interval": [
-            1.3343790021973443, 1.7404494893101918
+            1.334, 1.74
         ],
         "cpk_interval": [
-            0.28541323687295134, 0.5214709998854039
-        ]
+            0.285, 0.521
+        ],
+        "error": null
     },
     "file1007": {
         "data": [
@@ -16934,14 +18133,15 @@
         "lower_extreme": null,
         "upper_specification": -1.0,
         "lower_specification": -19.0,
-        "cp_point": 0.5475715691265723,
-        "cpk_point": 0.2971837872160637,
+        "cp_point": 0.548,
+        "cpk_point": 0.297,
         "cp_interval": [
-            0.4197421857244176, 0.6637546479256
+            0.42, 0.664
         ],
         "cpk_interval": [
-            0.16453331763126927, 0.39294339974467013
-        ]
+            0.165, 0.393
+        ],
+        "error": null
     },
     "file1008": {
         "data": [
@@ -16950,7 +18150,16 @@
         "upper_extreme": null,
         "lower_extreme": null,
         "upper_specification": 4.0,
-        "lower_specification": 0.0
+        "lower_specification": 0.0,
+        "cp_point": null,
+        "cpk_point": null,
+        "cp_interval": [
+            null, null
+        ],
+        "cpk_interval": [
+            null, null
+        ],
+        "error": "More unique values are required to calculate capability indexes."
     },
     "file1009": {
         "data": [
@@ -16960,14 +18169,15 @@
         "lower_extreme": null,
         "upper_specification": 11.0,
         "lower_specification": 5.0,
-        "cp_point": 1.2536125599560373,
-        "cpk_point": 1.2323293046582544,
+        "cp_point": 1.254,
+        "cpk_point": 1.232,
         "cp_interval": [
-            1.0104049889979403, 1.4661010174811335
+            1.01, 1.466
         ],
         "cpk_interval": [
-            0.961277936554156, 1.4226721170490413
-        ]
+            0.961, 1.423
+        ],
+        "error": null
     },
     "file1010": {
         "data": [
@@ -16977,14 +18187,15 @@
         "lower_extreme": null,
         "upper_specification": 11.0,
         "lower_specification": 5.0,
-        "cp_point": 0.9873456500673385,
-        "cpk_point": 0.5799748834682058,
+        "cp_point": 0.987,
+        "cpk_point": 0.58,
         "cp_interval": [
-            0.7882022330510033, 1.0861935455547171
+            0.788, 1.086
         ],
         "cpk_interval": [
-            0.48537315365137546, 0.6833723966181693
-        ]
+            0.485, 0.683
+        ],
+        "error": null
     },
     "file1011": {
         "data": [
@@ -16994,14 +18205,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.8384274845839705,
-        "cpk_point": 0.9229706200145575,
+        "cp_point": 1.915,
+        "cpk_point": 2.302,
         "cp_interval": [
-            1.5554210661633394, 2.1088436440940743
+            1.621, 2.197
         ],
         "cpk_interval": [
-            0.8559402355805213, 0.9783834704085095
-        ]
+            1.855, 2.734
+        ],
+        "error": null
     },
     "file1012": {
         "data": [
@@ -17011,14 +18223,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.9143595367423125,
-        "cpk_point": 0.9110977923463522,
+        "cp_point": 1.998,
+        "cpk_point": 2.428,
         "cp_interval": [
-            1.6221438210428003, 2.19277360154832
+            1.693, 2.288
         ],
         "cpk_interval": [
-            0.842953696502434, 0.9668582134486443
-        ]
+            1.962, 2.876
+        ],
+        "error": null
     },
     "file1013": {
         "data": [
@@ -17028,14 +18241,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 0.9134092046632983,
-        "cpk_point": 0.9052196407941796,
+        "cp_point": 0.957,
+        "cpk_point": 0.905,
         "cp_interval": [
-            0.7638603907459431, 1.0613476475385268
+            0.8, 1.112
         ],
         "cpk_interval": [
-            0.7171850285467127, 0.976819367596692
-        ]
+            0.717, 1.115
+        ],
+        "error": null
     },
     "file1014": {
         "data": [
@@ -17045,14 +18259,15 @@
         "lower_extreme": null,
         "upper_specification": 47.02,
         "lower_specification": 46.77,
-        "cp_point": 1.9405682336095753,
-        "cpk_point": 1.6699805628139452,
+        "cp_point": 1.941,
+        "cpk_point": 1.67,
         "cp_interval": [
-            1.6394854935379706, 2.218567512465412
+            1.639, 2.219
         ],
         "cpk_interval": [
-            1.3891996542156635, 1.9407354701236958
-        ]
+            1.389, 1.941
+        ],
+        "error": null
     },
     "file1015": {
         "data": [
@@ -17062,14 +18277,15 @@
         "lower_extreme": null,
         "upper_specification": 61.6,
         "lower_specification": 61.4,
-        "cp_point": 1.8516866897183233,
-        "cpk_point": 1.602229842806698,
+        "cp_point": 1.852,
+        "cpk_point": 1.602,
         "cp_interval": [
-            1.5704756145192884, 2.11625309077076
+            1.57, 2.116
         ],
         "cpk_interval": [
-            1.3491637816321478, 1.8425847442308987
-        ]
+            1.349, 1.843
+        ],
+        "error": null
     },
     "file1016": {
         "data": [
@@ -17079,14 +18295,15 @@
         "lower_extreme": null,
         "upper_specification": 58.248,
         "lower_specification": 58.207,
-        "cp_point": 0.8317023195397266,
-        "cpk_point": 0.5138286718831415,
+        "cp_point": 0.832,
+        "cpk_point": 0.514,
         "cp_interval": [
-            0.27654885634429516, 1.0156985005112473
+            0.277, 1.016
         ],
         "cpk_interval": [
-            0.13535836038050322, 0.7968452396691467
-        ]
+            0.135, 0.797
+        ],
+        "error": null
     },
     "file1017": {
         "data": [
@@ -17096,14 +18313,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": -6.0,
-        "cp_point": 1.174449348460344,
-        "cpk_point": 0.7253109317322471,
+        "cp_point": 1.174,
+        "cpk_point": 0.725,
         "cp_interval": [
-            0.7951398571664398, 1.4985865318073488
+            0.795, 1.499
         ],
         "cpk_interval": [
-            0.44563111986856646, 0.942177338569954
-        ]
+            0.446, 0.942
+        ],
+        "error": null
     },
     "file1018": {
         "data": [
@@ -17113,14 +18331,15 @@
         "lower_extreme": null,
         "upper_specification": 6.0,
         "lower_specification": -6.0,
-        "cp_point": 1.051184824561192,
-        "cpk_point": 1.0375956566123103,
+        "cp_point": 1.051,
+        "cpk_point": 1.038,
         "cp_interval": [
-            0.7062100238010384, 1.24885231524893
+            0.706, 1.249
         ],
         "cpk_interval": [
-            0.6135237646089241, 1.2146758961381323
-        ]
+            0.614, 1.215
+        ],
+        "error": null
     },
     "file1019": {
         "data": [
@@ -17130,14 +18349,15 @@
         "lower_extreme": null,
         "upper_specification": -11.0,
         "lower_specification": -29.0,
-        "cp_point": 0.9715016295282968,
-        "cpk_point": 0.7810910566267261,
+        "cp_point": 0.972,
+        "cpk_point": 0.781,
         "cp_interval": [
-            0.5657763431057723, 1.315853596075497
+            0.566, 1.316
         ],
         "cpk_interval": [
-            0.40153649797422286, 1.0787329858772146
-        ]
+            0.402, 1.079
+        ],
+        "error": null
     },
     "file1020": {
         "data": [
@@ -17147,14 +18367,15 @@
         "lower_extreme": null,
         "upper_specification": -1.0,
         "lower_specification": -19.0,
-        "cp_point": 0.8169660988264329,
-        "cpk_point": 0.6745785841226759,
+        "cp_point": 0.817,
+        "cpk_point": 0.675,
         "cp_interval": [
-            0.4516296898278362, 1.1183931313413389
+            0.452, 1.118
         ],
         "cpk_interval": [
-            0.32611579017072345, 0.9582454079193883
-        ]
+            0.326, 0.958
+        ],
+        "error": null
     },
     "file1021": {
         "data": [
@@ -17164,14 +18385,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.6745373093958932,
-        "cpk_point": 0.6573859303766011,
+        "cp_point": 0.832,
+        "cpk_point": 0.657,
         "cp_interval": [
-            0.39094449434443357, 0.9564137527862241
+            0.482, 1.179
         ],
         "cpk_interval": [
-            0.34422588022401124, 0.8151597219738425
-        ]
+            0.344, 1.046
+        ],
+        "error": null
     },
     "file1022": {
         "data": [
@@ -17181,14 +18403,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.9409055802742039,
-        "cpk_point": 0.8423787860067696,
+        "cp_point": 1.21,
+        "cpk_point": 1.069,
         "cp_interval": [
-            0.7115322424836815, 1.1291239795431967
+            0.915, 1.452
         ],
         "cpk_interval": [
-            0.6359502238135482, 1.03265668733447
-        ]
+            0.685, 1.413
+        ],
+        "error": null
     },
     "file1023": {
         "data": [
@@ -17198,14 +18421,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.5951054424867859,
-        "cpk_point": 0.7283135889428035,
+        "cp_point": 1.793,
+        "cpk_point": 1.859,
         "cp_interval": [
-            0.8672145554686477, 2.3252199287175097
+            0.975, 2.614
         ],
         "cpk_interval": [
-            0.539115461033516, 0.8549260157127662
-        ]
+            0.913, 2.934
+        ],
+        "error": null
     },
     "file1024": {
         "data": [
@@ -17215,14 +18439,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.9024987699311503,
-        "cpk_point": 0.745817466096644,
+        "cp_point": 1.018,
+        "cpk_point": 0.935,
         "cp_interval": [
-            0.42040765746377096, 1.4319758586472653
+            0.474, 1.615
         ],
         "cpk_interval": [
-            0.39682411390456973, 0.8515937270999651
-        ]
+            0.397, 1.629
+        ],
+        "error": null
     },
     "file1025": {
         "data": [
@@ -17232,14 +18457,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.8180611773200216,
-        "cpk_point": 0.7538595127870568,
+        "cp_point": 0.861,
+        "cpk_point": 0.754,
         "cp_interval": [
-            0.5508185765108293, 1.0722882185658793
+            0.58, 1.129
         ],
         "cpk_interval": [
-            0.44656125332286, 1.020408354385417
-        ]
+            0.447, 1.111
+        ],
+        "error": null
     },
     "file1026": {
         "data": [
@@ -17249,14 +18475,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.9608472135207352,
-        "cpk_point": 0.7425319665985597,
+        "cp_point": 1.109,
+        "cpk_point": 1.109,
         "cp_interval": [
-            0.7072277134511963, 1.1882737097392904
+            0.816, 1.371
         ],
         "cpk_interval": [
-            0.6066257531013055, 0.8563609909532767
-        ]
+            0.721, 1.51
+        ],
+        "error": null
     },
     "file1027": {
         "data": [
@@ -17266,14 +18493,15 @@
         "lower_extreme": null,
         "upper_specification": -11.0,
         "lower_specification": -29.0,
-        "cp_point": 0.760933175024641,
-        "cpk_point": -0.04131786865131758,
+        "cp_point": 0.761,
+        "cpk_point": -0.041,
         "cp_interval": [
-            0.39664230940568385, 1.0886767345589148
+            0.397, 1.089
         ],
         "cpk_interval": [
-            -0.16914993351015334, 0.10213245899856914
-        ]
+            -0.169, 0.102
+        ],
+        "error": null
     },
     "file1028": {
         "data": [
@@ -17283,14 +18511,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 1.0,
-        "cp_point": 1.2384926543523564,
-        "cpk_point": 0.9619892324592438,
+        "cp_point": 1.238,
+        "cpk_point": 0.962,
         "cp_interval": [
-            0.9208830606171042, 1.4841070810192771
+            0.921, 1.484
         ],
         "cpk_interval": [
-            0.6501898596379838, 1.3150746815736085
-        ]
+            0.65, 1.315
+        ],
+        "error": null
     },
     "file1029": {
         "data": [
@@ -17300,14 +18529,15 @@
         "lower_extreme": null,
         "upper_specification": -11.0,
         "lower_specification": -29.0,
-        "cp_point": 1.0126675149356505,
-        "cpk_point": -0.18424311541002164,
+        "cp_point": 1.013,
+        "cpk_point": -0.184,
         "cp_interval": [
-            0.5779588734278919, 1.3716988893646815
+            0.578, 1.372
         ],
         "cpk_interval": [
-            -0.35569375692333766, -0.013275885873422332
-        ]
+            -0.356, -0.013
+        ],
+        "error": null
     },
     "file1030": {
         "data": [
@@ -17317,14 +18547,15 @@
         "lower_extreme": null,
         "upper_specification": 7.0,
         "lower_specification": 1.0,
-        "cp_point": 1.0231967670568867,
-        "cpk_point": 0.6923367400750001,
+        "cp_point": 1.023,
+        "cpk_point": 0.692,
         "cp_interval": [
-            0.6815878565357221, 1.3206867264598015
+            0.682, 1.321
         ],
         "cpk_interval": [
-            0.4198115900127213, 1.0031535451221467
-        ]
+            0.42, 1.003
+        ],
+        "error": null
     },
     "file1031": {
         "data": [
@@ -17334,14 +18565,15 @@
         "lower_extreme": null,
         "upper_specification": -1.0,
         "lower_specification": -19.0,
-        "cp_point": 0.8895446236826737,
-        "cpk_point": 0.888428053434773,
+        "cp_point": 0.89,
+        "cpk_point": 0.888,
         "cp_interval": [
-            0.28841036309901485, 1.3605439984733316
+            0.288, 1.361
         ],
         "cpk_interval": [
-            0.20737109512389143, 1.1750320642632015
-        ]
+            0.207, 1.175
+        ],
+        "error": null
     },
     "file1032": {
         "data": [
@@ -17351,14 +18583,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.6936635049065814,
-        "cpk_point": 0.6602552010271009,
+        "cp_point": 1.694,
+        "cpk_point": 0.66,
         "cp_interval": [
-            1.1563832581399804, 2.170668732847773
+            1.156, 2.171
         ],
         "cpk_interval": [
-            0.4047432679935711, 0.9454232255364079
-        ]
+            0.405, 0.945
+        ],
+        "error": null
     },
     "file1033": {
         "data": [
@@ -17368,14 +18601,15 @@
         "lower_extreme": null,
         "upper_specification": -1.0,
         "lower_specification": -19.0,
-        "cp_point": 1.0229157425483124,
-        "cpk_point": 0.8372214180342278,
+        "cp_point": 1.023,
+        "cpk_point": 0.837,
         "cp_interval": [
-            0.3963789846961438, 1.5095676354523917
+            0.396, 1.51
         ],
         "cpk_interval": [
-            0.2355951597052421, 1.3449375811564896
-        ]
+            0.236, 1.345
+        ],
+        "error": null
     },
     "file1034": {
         "data": [
@@ -17385,14 +18619,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 0.675625804437887,
-        "cpk_point": 0.371562839368594,
+        "cp_point": 0.676,
+        "cpk_point": 0.372,
         "cp_interval": [
-            0.463056573786376, 0.8640223502106127
+            0.463, 0.864
         ],
         "cpk_interval": [
-            0.21635855204395185, 0.5688142211995154
-        ]
+            0.216, 0.569
+        ],
+        "error": null
     },
     "file1035": {
         "data": [
@@ -17402,14 +18637,15 @@
         "lower_extreme": null,
         "upper_specification": 11.0,
         "lower_specification": 5.0,
-        "cp_point": 0.5220107620467818,
-        "cpk_point": 0.5108896879471563,
+        "cp_point": 0.522,
+        "cpk_point": 0.511,
         "cp_interval": [
-            0.228580964481954, 0.76040150693687
+            0.229, 0.76
         ],
         "cpk_interval": [
-            0.19129041434480365, 0.677353815886954
-        ]
+            0.191, 0.677
+        ],
+        "error": null
     },
     "file1036": {
         "data": [
@@ -17419,14 +18655,15 @@
         "lower_extreme": null,
         "upper_specification": 11.0,
         "lower_specification": 5.0,
-        "cp_point": 0.9448647239934583,
-        "cpk_point": 0.563884392521997,
+        "cp_point": 0.945,
+        "cpk_point": 0.564,
         "cp_interval": [
-            0.5879482120507076, 1.266227189570656
+            0.588, 1.266
         ],
         "cpk_interval": [
-            0.3105995294278679, 0.8659296288000929
-        ]
+            0.311, 0.866
+        ],
+        "error": null
     },
     "file1037": {
         "data": [
@@ -17436,14 +18673,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 1.7045283944009098,
-        "cpk_point": 0.8649452621012463,
+        "cp_point": 1.818,
+        "cpk_point": 2.189,
         "cp_interval": [
-            1.2087253207435877, 2.153303263899877
+            1.289, 2.297
         ],
         "cpk_interval": [
-            0.7329614355094872, 0.9835365545937891
-        ]
+            1.395, 2.938
+        ],
+        "error": null
     },
     "file1038": {
         "data": [
@@ -17453,14 +18691,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 16.0,
         "lower_specification": null,
-        "cp_point": 2.2091339762176796,
-        "cpk_point": 0.6579621029283416,
+        "cp_point": 2.466,
+        "cpk_point": 3.249,
         "cp_interval": [
-            1.6139134681571379, 2.736007112065899
+            1.802, 3.054
         ],
         "cpk_interval": [
-            0.47847798665625363, 0.7895852982490643
-        ]
+            2.183, 4.184
+        ],
+        "error": null
     },
     "file1039": {
         "data": [
@@ -17470,14 +18709,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 22.0,
         "lower_specification": null,
-        "cp_point": 1.0935972880293399,
-        "cpk_point": 0.8190344625395571,
+        "cp_point": 1.318,
+        "cpk_point": 1.261,
         "cp_interval": [
-            0.8324936749416159, 1.3041761219409767
+            1.004, 1.572
         ],
         "cpk_interval": [
-            0.5210993214990142, 0.9273322215007105
-        ]
+            0.839, 1.652
+        ],
+        "error": null
     },
     "file1040": {
         "data": [
@@ -17487,14 +18727,15 @@
         "lower_extreme": null,
         "upper_specification": 47.02,
         "lower_specification": 46.77,
-        "cp_point": 1.2310904244821517,
-        "cpk_point": 1.0475002275202787,
+        "cp_point": 1.231,
+        "cpk_point": 1.048,
         "cp_interval": [
-            0.748058202568284, 1.6469429350470806
+            0.748, 1.647
         ],
         "cpk_interval": [
-            0.5901364811025523, 1.4123239224156445
-        ]
+            0.59, 1.412
+        ],
+        "error": null
     },
     "file1041": {
         "data": [
@@ -17504,14 +18745,15 @@
         "lower_extreme": null,
         "upper_specification": 61.6,
         "lower_specification": 61.4,
-        "cp_point": 2.124971006502563,
-        "cpk_point": 1.8678031826137542,
+        "cp_point": 2.125,
+        "cpk_point": 1.868,
         "cp_interval": [
-            1.462493557548511, 2.702327137189595
+            1.462, 2.702
         ],
         "cpk_interval": [
-            1.3389159265922244, 2.330006087402594
-        ]
+            1.339, 2.33
+        ],
+        "error": null
     },
     "file1042": {
         "data": [
@@ -17521,14 +18763,15 @@
         "lower_extreme": null,
         "upper_specification": 58.248,
         "lower_specification": 58.207,
-        "cp_point": 0.20197376416790128,
-        "cpk_point": 0.11638502107736767,
+        "cp_point": 0.202,
+        "cpk_point": 0.116,
         "cp_interval": [
-            0.12303678631782879, 0.2680504682295829
+            0.123, 0.268
         ],
         "cpk_interval": [
-            0.017181593198041023, 0.20577484057880072
-        ]
+            0.017, 0.206
+        ],
+        "error": null
     },
     "file1043": {
         "data": [
@@ -17538,14 +18781,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 20.0,
         "lower_specification": null,
-        "cp_point": 0.3461086299385974,
-        "cpk_point": 0.21036867348025126,
+        "cp_point": 0.364,
+        "cpk_point": 0.21,
         "cp_interval": [
-            0.2596673826421122, 0.44745171937834094
+            0.273, 0.471
         ],
         "cpk_interval": [
-            0.1420840323563813, 0.305437948126484
-        ]
+            0.142, 0.305
+        ],
+        "error": null
     },
     "file1044": {
         "data": [
@@ -17555,14 +18799,15 @@
         "lower_extreme": null,
         "upper_specification": 41.94,
         "lower_specification": 41.67,
-        "cp_point": 1.7822819435254291,
-        "cpk_point": 1.4971456088889086,
+        "cp_point": 1.782,
+        "cpk_point": 1.497,
         "cp_interval": [
-            1.5704023428674254, 1.983433838681851
+            1.57, 1.983
         ],
         "cpk_interval": [
-            1.2459289254150194, 1.8035037679715362
-        ]
+            1.246, 1.804
+        ],
+        "error": null
     },
     "file1045": {
         "data": [
@@ -17572,14 +18817,15 @@
         "lower_extreme": null,
         "upper_specification": 53.0,
         "lower_specification": 52.85,
-        "cp_point": 1.2326991058450323,
-        "cpk_point": 0.7695851279805889,
+        "cp_point": 1.233,
+        "cpk_point": 0.77,
         "cp_interval": [
-            1.0702221240671654, 1.327853211546549
+            1.07, 1.328
         ],
         "cpk_interval": [
-            0.6422374120171671, 0.8548708618226871
-        ]
+            0.642, 0.855
+        ],
+        "error": null
     },
     "file1046": {
         "data": [
@@ -17589,14 +18835,15 @@
         "lower_extreme": null,
         "upper_specification": 50.122,
         "lower_specification": 50.077,
-        "cp_point": 0.3746874461706587,
-        "cpk_point": 0.2008269044886926,
+        "cp_point": 0.375,
+        "cpk_point": 0.201,
         "cp_interval": [
-            0.30088273994778897, 0.41482813712675143
+            0.301, 0.415
         ],
         "cpk_interval": [
-            0.1488111667066518, 0.23607947126295828
-        ]
+            0.149, 0.236
+        ],
+        "error": null
     },
     "file1047": {
         "data": [
@@ -17606,14 +18853,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": -5.0,
-        "cp_point": 1.4699230625203084,
-        "cpk_point": 1.2718921532559477,
+        "cp_point": 1.47,
+        "cpk_point": 1.272,
         "cp_interval": [
-            1.221734762628297, 1.6218619364082882
+            1.222, 1.622
         ],
         "cpk_interval": [
-            1.0009006667873026, 1.5034960981408085
-        ]
+            1.001, 1.503
+        ],
+        "error": null
     },
     "file1048": {
         "data": [
@@ -17623,14 +18871,15 @@
         "lower_extreme": null,
         "upper_specification": 5.0,
         "lower_specification": -5.0,
-        "cp_point": 1.7293403168075332,
-        "cpk_point": 1.2210189768997306,
+        "cp_point": 1.729,
+        "cpk_point": 1.221,
         "cp_interval": [
-            1.456167825668154, 1.9735263937658916
+            1.456, 1.974
         ],
         "cpk_interval": [
-            1.0015820945107332, 1.44904299888236
-        ]
+            1.002, 1.449
+        ],
+        "error": null
     },
     "file1049": {
         "data": [
@@ -17640,14 +18889,15 @@
         "lower_extreme": null,
         "upper_specification": -21.0,
         "lower_specification": -39.0,
-        "cp_point": 1.3435714136422174,
-        "cpk_point": 1.1670298908543706,
+        "cp_point": 1.344,
+        "cpk_point": 1.167,
         "cp_interval": [
-            1.1443954210936838, 1.5203431947573007
+            1.144, 1.52
         ],
         "cpk_interval": [
-            0.9776603134131131, 1.322791919199075
-        ]
+            0.978, 1.323
+        ],
+        "error": null
     },
     "file1050": {
         "data": [
@@ -17657,14 +18907,15 @@
         "lower_extreme": null,
         "upper_specification": 9.0,
         "lower_specification": -9.0,
-        "cp_point": 1.3402020374899863,
-        "cpk_point": 1.0834107882095296,
+        "cp_point": 1.34,
+        "cpk_point": 1.083,
         "cp_interval": [
-            1.144776851452801, 1.5381226104803765
+            1.145, 1.538
         ],
         "cpk_interval": [
-            0.8925873585759799, 1.2781149256983957
-        ]
+            0.893, 1.278
+        ],
+        "error": null
     },
     "file1051": {
         "data": [
@@ -17674,14 +18925,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.6737584433206756,
-        "cpk_point": 0.5885483780179773,
+        "cp_point": 0.823,
+        "cpk_point": 0.589,
         "cp_interval": [
-            0.5882092871893411, 0.7552675931486742
+            0.718, 0.922
         ],
         "cpk_interval": [
-            0.47626995531964506, 0.7137617451520888
-        ]
+            0.476, 0.714
+        ],
+        "error": null
     },
     "file1052": {
         "data": [
@@ -17691,14 +18943,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 3.0,
         "lower_specification": null,
-        "cp_point": 0.6869035086515528,
-        "cpk_point": 0.661694744881605,
+        "cp_point": 0.83,
+        "cpk_point": 0.662,
         "cp_interval": [
-            0.5482950988350263, 0.8265748844823101
+            0.662, 0.998
         ],
         "cpk_interval": [
-            0.5031393283413707, 0.7879906992017589
-        ]
+            0.503, 0.848
+        ],
+        "error": null
     },
     "file1053": {
         "data": [
@@ -17708,14 +18961,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.9911835924109156,
-        "cpk_point": 0.7778424583297092,
+        "cp_point": 1.106,
+        "cpk_point": 1.055,
         "cp_interval": [
-            0.7874313534609486, 1.1990868258461804
+            0.879, 1.338
         ],
         "cpk_interval": [
-            0.7024478070820719, 0.8348892121429793
-        ]
+            0.801, 1.338
+        ],
+        "error": null
     },
     "file1054": {
         "data": [
@@ -17725,14 +18979,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 1.2749302882334086,
-        "cpk_point": 0.7998235723257261,
+        "cp_point": 1.43,
+        "cpk_point": 1.698,
         "cp_interval": [
-            1.0790255707264689, 1.4945063673239685
+            1.211, 1.677
         ],
         "cpk_interval": [
-            0.7396390666619418, 0.8681354445594215
-        ]
+            1.318, 2.154
+        ],
+        "error": null
     },
     "file1055": {
         "data": [
@@ -17742,14 +18997,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.8682866453777277,
-        "cpk_point": 0.7970133967705471,
+        "cp_point": 0.914,
+        "cpk_point": 0.797,
         "cp_interval": [
-            0.7335830032725668, 0.997368018482515
+            0.772, 1.05
         ],
         "cpk_interval": [
-            0.6404233780372697, 0.9738574578192373
-        ]
+            0.64, 0.974
+        ],
+        "error": null
     },
     "file1056": {
         "data": [
@@ -17759,14 +19015,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 5.0,
         "lower_specification": null,
-        "cp_point": 0.7658698941584323,
-        "cpk_point": 0.7276472576439726,
+        "cp_point": 0.862,
+        "cpk_point": 0.728,
         "cp_interval": [
-            0.6434013235807862, 0.8847033326993222
+            0.724, 0.995
         ],
         "cpk_interval": [
-            0.5786473789784619, 0.8634228432243208
-        ]
+            0.579, 0.897
+        ],
+        "error": null
     },
     "file1057": {
         "data": [
@@ -17776,14 +19033,15 @@
         "lower_extreme": null,
         "upper_specification": -21.0,
         "lower_specification": -39.0,
-        "cp_point": 0.5784727219603963,
-        "cpk_point": 0.43617814866667826,
+        "cp_point": 0.578,
+        "cpk_point": 0.436,
         "cp_interval": [
-            0.46062235054935824, 0.6814622207975888
+            0.461, 0.681
         ],
         "cpk_interval": [
-            0.33983254351746794, 0.5538627341518112
-        ]
+            0.34, 0.554
+        ],
+        "error": null
     },
     "file1058": {
         "data": [
@@ -17793,14 +19051,15 @@
         "lower_extreme": null,
         "upper_specification": -21.0,
         "lower_specification": -39.0,
-        "cp_point": 0.7051708082462801,
-        "cpk_point": 0.42145439978854554,
+        "cp_point": 0.705,
+        "cpk_point": 0.421,
         "cp_interval": [
-            0.576156454515385, 0.8195184659280542
+            0.576, 0.82
         ],
         "cpk_interval": [
-            0.3056336434442354, 0.5170126930756098
-        ]
+            0.306, 0.517
+        ],
+        "error": null
     },
     "file1059": {
         "data": [
@@ -17810,14 +19069,15 @@
         "lower_extreme": null,
         "upper_specification": 9.0,
         "lower_specification": -9.0,
-        "cp_point": 0.8309221600031214,
-        "cpk_point": 0.37517614709013486,
+        "cp_point": 0.831,
+        "cpk_point": 0.375,
         "cp_interval": [
-            0.6754829100889691, 0.9701974009587562
+            0.675, 0.97
         ],
         "cpk_interval": [
-            0.2838267517663529, 0.4910786363202546
-        ]
+            0.284, 0.491
+        ],
+        "error": null
     },
     "file1060": {
         "data": [
@@ -17827,14 +19087,15 @@
         "lower_extreme": null,
         "upper_specification": 9.0,
         "lower_specification": -9.0,
-        "cp_point": 0.7120241468525691,
-        "cpk_point": 0.6527888433959202,
+        "cp_point": 0.712,
+        "cpk_point": 0.653,
         "cp_interval": [
-            0.5817492965492154, 0.8340045529658076
+            0.582, 0.834
         ],
         "cpk_interval": [
-            0.5141625056279034, 0.8048445722676316
-        ]
+            0.514, 0.805
+        ],
+        "error": null
     },
     "file1061": {
         "data": [
@@ -17844,14 +19105,15 @@
         "lower_extreme": null,
         "upper_specification": 10.0,
         "lower_specification": 2.0,
-        "cp_point": 1.4690091511967942,
-        "cpk_point": 1.09225348614589,
+        "cp_point": 1.469,
+        "cpk_point": 1.092,
         "cp_interval": [
-            1.2525936435947405, 1.6660856401261421
+            1.253, 1.666
         ],
         "cpk_interval": [
-            0.9244405617419059, 1.2263197105387718
-        ]
+            0.924, 1.226
+        ],
+        "error": null
     },
     "file1062": {
         "data": [
@@ -17861,14 +19123,15 @@
         "lower_extreme": null,
         "upper_specification": 10.0,
         "lower_specification": 2.0,
-        "cp_point": 1.3014983783987786,
-        "cpk_point": 1.0343524300745306,
+        "cp_point": 1.301,
+        "cpk_point": 1.034,
         "cp_interval": [
-            1.0953658713795125, 1.4374890296355607
+            1.095, 1.437
         ],
         "cpk_interval": [
-            0.8578604109061575, 1.1808345931198778
-        ]
+            0.858, 1.181
+        ],
+        "error": null
     },
     "file1063": {
         "data": [
@@ -17878,14 +19141,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.0972535556102532,
-        "cpk_point": 0.3852877236704,
+        "cp_point": 1.097,
+        "cpk_point": 0.385,
         "cp_interval": [
-            0.9383720188960947, 1.2464810472367707
+            0.938, 1.246
         ],
         "cpk_interval": [
-            0.3092651395961627, 0.47790875549716394
-        ]
+            0.309, 0.478
+        ],
+        "error": null
     },
     "file1064": {
         "data": [
@@ -17895,14 +19159,15 @@
         "lower_extreme": null,
         "upper_specification": 4.0,
         "lower_specification": 0.0,
-        "cp_point": 1.5896494516228832,
-        "cpk_point": 0.5637761914651094,
+        "cp_point": 1.59,
+        "cpk_point": 0.564,
         "cp_interval": [
-            1.2828022734443296, 1.7826532478333095
+            1.283, 1.783
         ],
         "cpk_interval": [
-            0.4136800272607646, 0.6632861951725976
-        ]
+            0.414, 0.663
+        ],
+        "error": null
     },
     "file1065": {
         "data": [
@@ -17912,14 +19177,15 @@
         "lower_extreme": null,
         "upper_specification": 14.0,
         "lower_specification": 6.0,
-        "cp_point": 1.9773472729035868,
-        "cpk_point": 1.436825410916218,
+        "cp_point": 1.977,
+        "cpk_point": 1.437,
         "cp_interval": [
-            1.6051522138609315, 2.3825277170267385
+            1.605, 2.383
         ],
         "cpk_interval": [
-            1.1408082060137203, 1.778824798830392
-        ]
+            1.141, 1.779
+        ],
+        "error": null
     },
     "file1066": {
         "data": [
@@ -17929,14 +19195,15 @@
         "lower_extreme": null,
         "upper_specification": 14.0,
         "lower_specification": 6.0,
-        "cp_point": 0.9010926058643688,
-        "cpk_point": 0.6874162510964712,
+        "cp_point": 0.901,
+        "cpk_point": 0.687,
         "cp_interval": [
-            0.2624237536425881, 1.2782229714377724
+            0.262, 1.278
         ],
         "cpk_interval": [
-            0.15074245025428057, 1.2184567827409785
-        ]
+            0.151, 1.218
+        ],
+        "error": null
     },
     "file1067": {
         "data": [
@@ -17946,14 +19213,15 @@
         "lower_extreme": 0.0,
         "upper_specification": 11.0,
         "lower_specification": null,
-        "cp_point": 0.6953240599415098,
-        "cpk_point": 0.5799977355945467,
+        "cp_point": 0.746,
+        "cpk_point": 0.58,
         "cp_interval": [
-            0.5899115895651007, 0.798144057741607
+            0.633, 0.857
         ],
         "cpk_interval": [
-            0.4580592831638557, 0.7192073788254543
-        ]
+            0.458, 0.719
+        ],
+        "error": null
     },
     "file1068": {
         "data": [
@@ -17963,13 +19231,14 @@
         "lower_extreme": 0.0,
         "upper_specification": 11.0,
         "lower_specification": null,
-        "cp_point": 0.6885269467543109,
-        "cpk_point": 0.5846627213208874,
+        "cp_point": 0.735,
+        "cpk_point": 0.585,
         "cp_interval": [
-            0.5825056168554158, 0.7933347607798098
+            0.622, 0.847
         ],
         "cpk_interval": [
-            0.46059914861926204, 0.7268739894185998
-        ]
+            0.461, 0.727
+        ],
+        "error": null
     }
 }


### PR DESCRIPTION
Recalculated all test values, rounded them to 3 decimals, because we are checking first two decimals anyway and added error checking if the data was not appropriate. Now it is possible to check for errors too, for example we can check for  "More unique values are required to calculate capability indexes." error.